### PR TITLE
fix(studio) Renamed node is deconnected from the parent node 

### DIFF
--- a/packages/studio-ui/src/web/reducers/flows.ts
+++ b/packages/studio-ui/src/web/reducers/flows.ts
@@ -472,7 +472,7 @@ reducer = reduceReducers(
               const next = node.next.map((value, index) => {
                 const link = nodeLinks.find(link => Number(link.sourcePort.replace('out', '')) === index)
                 const targetNode = _.find(currentFlow.nodes, { id: (link || {}).target })
-                return { ...value, node: _.get(targetNode,'name') || value.node }
+                return { ...value, node: _.get(targetNode, 'name') || value.node }
               })
 
               return { ...node, next, lastModified: new Date() }

--- a/packages/studio-ui/src/web/reducers/flows.ts
+++ b/packages/studio-ui/src/web/reducers/flows.ts
@@ -472,13 +472,7 @@ reducer = reduceReducers(
               const next = node.next.map((value, index) => {
                 const link = nodeLinks.find(link => Number(link.sourcePort.replace('out', '')) === index)
                 const targetNode = _.find(currentFlow.nodes, { id: (link || {}).target })
-                let remapNode = ''
-
-                if (value.node.includes('.flow.json') || value.node === 'END' || value.node.startsWith('#')) {
-                  remapNode = value.node
-                }
-
-                return { ...value, node: (targetNode && targetNode.name) || remapNode }
+                return { ...value, node: _.get(targetNode,'name') || value.node }
               })
 
               return { ...node, next, lastModified: new Date() }


### PR DESCRIPTION
I created a PR for this issue #20.

If a linked node is renamed, the link between the source and the output is removed  



## Example of the bug 
https://user-images.githubusercontent.com/6981314/128202726-3e6f3fd6-2fc1-4435-a29f-8acc36f32df6.mov

