### PR TITLE
feat(studio): add support for help/hints with content form

### DIFF
--- a/packages/studio-ui/package.json
+++ b/packages/studio-ui/package.json
@@ -108,6 +108,7 @@
     "@types/lodash": "^4.14.133",
     "@types/react": "^16.8.6",
     "@types/react-dom": "^16.8.6",
+    "@types/react-jsonschema-form": "^1.7.5",
     "@types/react-router-dom": "^4.3.3",
     "@types/slate": "0.47.1",
     "@types/slate-react": "0.22.5",

--- a/packages/studio-ui/src/web/components/ContentForm/UploadWidget/index.tsx
+++ b/packages/studio-ui/src/web/components/ContentForm/UploadWidget/index.tsx
@@ -1,22 +1,20 @@
 import axios from 'axios'
-import { FormFields, lang, UploadFieldProps } from 'botpress/shared'
+import { FormFields, lang, SupportedFileType } from 'botpress/shared'
 import cn from 'classnames'
+import { isBpUrl } from 'common/url'
 import React, { FC, Fragment, useState } from 'react'
 import { AccessControl } from '~/components/Shared/Utils'
 import style from '~/views/FlowBuilder/sidePanelTopics/form/style.scss'
 
-import { isBpUrl } from '../../../../../../studio-be/out/common/url'
+import { Schema } from '../typings'
 
 import localStyle from './style.scss'
 import UrlUpload from './UrlUpload'
 interface IUploadWidgetProps {
   value: string | null
   onChange(value: string | null): void
-  schema: {
-    type: string
-    $subtype: UploadFieldProps['type']
-    $filter: string
-    title: string
+  schema: Schema & {
+    $subtype: SupportedFileType
   }
 }
 

--- a/packages/studio-ui/src/web/components/ContentForm/index.tsx
+++ b/packages/studio-ui/src/web/components/ContentForm/index.tsx
@@ -1,8 +1,9 @@
-import { Colors, Icon } from '@blueprintjs/core'
-import { lang, UploadFieldProps } from 'botpress/shared'
+import { Icon } from '@blueprintjs/core'
+import { lang, SupportedFileType } from 'botpress/shared'
 import _ from 'lodash'
 import React, { FC } from 'react'
-import Form from 'react-jsonschema-form'
+import Form, { FieldProps, IChangeEvent, UiSchema, WidgetProps } from 'react-jsonschema-form'
+import CheckboxWidget from 'react-jsonschema-form/lib/components/widgets/CheckboxWidget'
 import SmartInput from '~/components/SmartInput'
 import { getFormData } from '~/util/NodeFormData'
 import style from '~/views/FlowBuilder/sidePanelTopics/form/style.scss'
@@ -16,29 +17,40 @@ import renderWrapped from './i18n/I18nWrapper'
 import RefWidget from './RefWidget'
 import localStyle from './style.scss'
 import Text from './Text'
+import { Fields, Schema, Widgets } from './typings'
 import UploadWidget from './UploadWidget'
 
 interface Props {
   contentLang: string
   onChange: any
-  formData: any
+  formData: FormData
   customKey: string
-  schema: any
+  schema: Schema
+  uiSchema: UiSchema
   defaultLanguage: string
 }
 
-const CustomBaseInput = props => {
-  const SUPPORTED_MEDIA_SUBTYPES: UploadFieldProps['type'][] = ['audio', 'image', 'video', 'file']
-  const { type, $subtype: subtype } = props.schema
+const CustomBaseInput = (props: WidgetProps) => {
+  const SUPPORTED_MEDIA_SUBTYPES: SupportedFileType[] = ['audio', 'image', 'video', 'file']
+  const { type, $subtype: subtype } = props.schema as Schema
   const { readonly } = props.options
 
   if (type === 'string') {
     if (subtype === 'ref') {
       return <RefWidget key={props?.formContext?.customKey} {...props} />
-    } else if (SUPPORTED_MEDIA_SUBTYPES.includes(subtype)) {
-      return <UploadWidget key={props?.formContext?.customKey} {...props} />
     } else if (subtype === 'flow') {
       return <FlowPickWidget key={props?.formContext?.customKey} {...props} />
+    } else if (SUPPORTED_MEDIA_SUBTYPES.includes(subtype)) {
+      return (
+        <UploadWidget
+          key={props?.formContext?.customKey}
+          {...props}
+          schema={{
+            ...(props.schema as Schema),
+            $subtype: subtype
+          }}
+        />
+      )
     }
   }
 
@@ -47,18 +59,40 @@ const CustomBaseInput = props => {
       key={props?.formContext?.customKey}
       {...props}
       singleLine={true}
-      readOnly={readonly}
+      readOnly={Boolean(readonly)}
       className={style.textarea}
     />
   )
 }
 
-const widgets = {
-  BaseInput: CustomBaseInput
+const CustomCheckboxWidget = (props: WidgetProps) => {
+  const { $help: help } = props.schema as Schema
+
+  if (help) {
+    const { text, link } = help
+    return (
+      <div>
+        <CheckboxWidget {...props} />
+        <span>{lang.tr(text)}</span>
+        {link && (
+          <a href={link} target="_blank">
+            {link}
+          </a>
+        )}
+      </div>
+    )
+  }
+
+  return <CheckboxWidget {...props} />
+}
+
+const widgets: Widgets = {
+  BaseInput: CustomBaseInput,
+  CheckboxWidget: CustomCheckboxWidget
 }
 
 // TODO: Remove this once audio and video content-types are support on multiple channels
-const CustomDescriptionField = ({ description, id, formContext }) => {
+const CustomDescriptionField = ({ description, id, formContext }: FieldProps) => {
   if (id === 'root__description' && ['audio', 'video', 'location', 'file'].includes(formContext.subtype)) {
     const capitalize = (str: string) => {
       return str.charAt(0).toUpperCase() + str.slice(1)
@@ -81,20 +115,20 @@ const CustomDescriptionField = ({ description, id, formContext }) => {
   }
 }
 
-const fields = {
+const fields: Fields = {
   i18n_field: renderWrapped(Text),
-  i18n_array: ArrayMl,
+  i18n_array: ArrayMl as any, // TODO: Fix typings with ArrayMl class component
   DescriptionField: CustomDescriptionField
 }
 
-const translatePropsRecursive = obj => {
+const translatePropsRecursive = (schema: Schema) => {
   return _.reduce(
-    obj,
+    schema,
     (result, value, key) => {
       if ((key === 'title' || key === 'description') && typeof value === 'string') {
         result[key] = lang.tr(value)
       } else if (_.isObject(value) && !_.isArray(value)) {
-        result[key] = translatePropsRecursive(value)
+        result[key] = translatePropsRecursive(value as Schema)
       } else {
         result[key] = value
       }
@@ -106,7 +140,7 @@ const translatePropsRecursive = obj => {
 }
 
 const ContentForm: FC<Props> = props => {
-  const handleOnChange = event => {
+  const handleOnChange = (event: IChangeEvent<FormData>) => {
     const newFields = Object.keys(event.formData).reduce((obj, key) => {
       obj[`${key}$${props.contentLang}`] = event.formData[key]
       return obj
@@ -123,7 +157,12 @@ const ContentForm: FC<Props> = props => {
 
   const { formData, contentLang, defaultLanguage, schema } = props
 
-  const currentFormData = getFormData({ formData }, contentLang, defaultLanguage, schema.type === 'array' ? [] : {})
+  const currentFormData: FormData = getFormData(
+    { formData },
+    contentLang,
+    defaultLanguage,
+    schema.type === 'array' ? [] : {}
+  )
 
   const context = {
     ...formData,
@@ -134,7 +173,7 @@ const ContentForm: FC<Props> = props => {
   }
 
   return (
-    <Form
+    <Form<FormData>
       {...props}
       formData={currentFormData}
       formContext={context}

--- a/packages/studio-ui/src/web/components/ContentForm/typings.ts
+++ b/packages/studio-ui/src/web/components/ContentForm/typings.ts
@@ -1,0 +1,20 @@
+import { SupportedFileType } from 'botpress/shared'
+
+import { JSONSchema6 } from 'json-schema'
+import { FormProps } from 'react-jsonschema-form'
+
+export type Schema = JSONSchema6 & {
+  $subtype: 'ref' | 'flow' | SupportedFileType
+  $filter: string
+  $help: {
+    text: string
+    link?: string
+  }
+}
+
+export interface FormData {
+  [key: string]: string | boolean | Array<Object>
+}
+
+export type Fields = FormProps<FormData>['fields']
+export type Widgets = FormProps<FormData>['widgets']

--- a/packages/ui-shared/src/FileDisplay/index.tsx
+++ b/packages/ui-shared/src/FileDisplay/index.tsx
@@ -8,6 +8,7 @@ import { FileDisplayProps } from './typings'
 const FileDisplay: FC<FileDisplayProps> = props => {
   const { url, type, deletable, onDelete } = props
 
+  const filename = url.substring(url.lastIndexOf('/') + 1)
   const mimeType = mime.lookup(url) || undefined
 
   const deletableFile = () => (
@@ -41,6 +42,15 @@ const FileDisplay: FC<FileDisplayProps> = props => {
             <source src={url} type={mimeType} />
             Your browser does not support the video element.
           </video>
+        </div>
+      )
+    case 'file':
+      return (
+        <div className={style.fileWrapper}>
+          <div className={style.fileWrapperActions}>{deletable && deletableFile()}</div>
+          <a href={url} target="_blank" className={style.fileWrapperFile}>
+            {filename}
+          </a>
         </div>
       )
     default:

--- a/packages/ui-shared/src/FileDisplay/style.scss
+++ b/packages/ui-shared/src/FileDisplay/style.scss
@@ -70,3 +70,20 @@
     background-color: rgba(30, 30, 30, 0.5);
   }
 }
+
+.fileWrapper {
+  position: relative;
+  height: 50px;
+
+  &Actions {
+    position: absolute;
+    right: 5px;
+    top: 5px;
+  }
+
+  &File {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+  }
+}

--- a/packages/ui-shared/src/FileDisplay/style.scss.d.ts
+++ b/packages/ui-shared/src/FileDisplay/style.scss.d.ts
@@ -5,6 +5,9 @@ interface CssExports {
   'audioWrapperActions': string;
   'audioWrapperSource': string;
   'deleteFile': string;
+  'fileWrapper': string;
+  'fileWrapperActions': string;
+  'fileWrapperFile': string;
   'imageWrapper': string;
   'imageWrapperActions': string;
   'videoWrapper': string;

--- a/packages/ui-shared/src/Form/FormFields/typings.d.ts
+++ b/packages/ui-shared/src/Form/FormFields/typings.d.ts
@@ -59,7 +59,7 @@ export interface FieldWrapperProps {
 
 export type TextProps = FieldProps & { field: FormField }
 
-export type SupportedFileType = 'image' | 'audio' | 'video'
+export type SupportedFileType = 'image' | 'audio' | 'video' | 'file'
 
 export interface UploadFieldProps extends FieldProps {
   axios: any

--- a/packages/ui-shared/src/typings.d.ts
+++ b/packages/ui-shared/src/typings.d.ts
@@ -31,7 +31,8 @@ import {
   SelectProps,
   TextFieldsArrayProps,
   TextProps,
-  UploadFieldProps
+  UploadFieldProps,
+  SupportedFileType
 } from './Form/FormFields/typings'
 import { FormProps } from './Form/typings'
 
@@ -150,7 +151,14 @@ declare module 'botpress/shared' {
   export const sharedStyle: CssExports
   export { ModuleUI }
   export { Option, MoreOptionsItems, HeaderButtonProps, ToolbarButtonProps, QuickShortcut, MenuItem, HeaderButton }
-  export { RequiredPermission, PermissionAllowedProps, AccessControlProps, PermissionOperation, UploadFieldProps }
+  export {
+    RequiredPermission,
+    PermissionAllowedProps,
+    AccessControlProps,
+    PermissionOperation,
+    UploadFieldProps,
+    SupportedFileType
+  }
 }
 
 declare global {

--- a/yarn.lock
+++ b/yarn.lock
@@ -953,7 +953,7 @@
   resolved "https://registry.npmjs.org/@types/joi/-/joi-13.6.3.tgz#79364839a9cc2c6d4d915ef8822e1f703e28648f"
   integrity sha512-n5tDa0/3MUtHsA2fVH+emDfGQkPramIpWaOvWS+7C/Yq7bn2j979RAIy9pbl4F4hSE5lwjgBXhJN019DP+3ofg==
 
-"@types/json-schema@^7.0.5", "@types/json-schema@^7.0.7":
+"@types/json-schema@*", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.7":
   version "7.0.7"
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
@@ -1031,6 +1031,14 @@
   integrity sha512-34Hr3XnmUSJbUVDxIw/e7dhQn2BJZhJmlAaPyPwfTQyuVS9mV/CeyghFcXyvkJXxI7notQJz8mF8FeCVvloJrA==
   dependencies:
     "@types/react" "^16"
+
+"@types/react-jsonschema-form@^1.7.5":
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/@types/react-jsonschema-form/-/react-jsonschema-form-1.7.5.tgz#1b08327662afd610a93f28e33950e00e6e848581"
+  integrity sha512-Ovhmu9WOAHee0GNCncNiTRtUmrVZgj8vkdEwc3f0CgvkNIYss9ucQ1F6TNLuakXumAg25P1zGgeCqr37iJo5FQ==
+  dependencies:
+    "@types/json-schema" "*"
+    "@types/react" "*"
 
 "@types/react-router-dom@^4.3.3":
   version "4.3.5"


### PR DESCRIPTION
This PR adds the ability to display help/hints under form fields. Also contains some changes that were missing from: https://github.com/botpress/botpress/pull/5045

![Screenshot from 2021-06-21 17-36-34](https://user-images.githubusercontent.com/9640576/122831868-801afd80-d2b8-11eb-842b-ef7e47a565ba.png)

Related to this PR: https://github.com/botpress/botpress/pull/5131