### PR TITLE
fix(studio): UI toast modifications

### DIFF
--- a/packages/ui-shared/src/Toaster/index.tsx
+++ b/packages/ui-shared/src/Toaster/index.tsx
@@ -50,7 +50,14 @@ const warningOptions = {
   key: 'warning'
 }
 
-const selectToaster = (options?: IToasterProps) => (options ? Toaster.create(options) : defaultToaster)
+function selectToaster(options?: IToasterProps) {
+  if (options) {
+    options.className = style.toaster
+    return Toaster.create(options)
+  } else {
+    return defaultToaster
+  }
+}
 
 const dismiss = (key: string, options?: IToasterProps) => {
   if (!toastKeys[key]) {

--- a/packages/ui-shared/src/Toaster/index.tsx
+++ b/packages/ui-shared/src/Toaster/index.tsx
@@ -12,7 +12,7 @@ export interface ToastOptions {
   icon?: IconName | JSX.Element
   hideDismiss?: boolean
   key?: string
-  toasterProperties?: IToasterProps
+  toasterProps?: IToasterProps
   onDismiss?: (didTimeoutExpire: boolean) => void
 }
 
@@ -50,13 +50,7 @@ const warningOptions = {
   key: 'warning'
 }
 
-const selectToaster = (options?: IToasterProps) => {
-  if(options){
-    return Toaster.create(options)
-  } else{
-    return defaultToaster
-  }
-}
+const selectToaster = (options?) => options ? Toaster.create(options) : defaultToaster
 
 const dismiss = (key: string, options?: IToasterProps) => {
   if (!toastKeys[key]) {
@@ -90,9 +84,9 @@ const showToast = (message: string | React.ReactElement, intent, options: ToastO
   }
 
   const showToast = () => {
-    dismiss(options.key! , options.toasterProperties)
+    dismiss(options.key! , options.toasterProps)
 
-    toastKeys[options.key!] = selectToaster(options.toasterProperties).show({
+    toastKeys[options.key!] = selectToaster(options.toasterProps).show({
       message: typeof message === 'string' ? lang(message) : message,
       intent,
       timeout,

--- a/packages/ui-shared/src/Toaster/index.tsx
+++ b/packages/ui-shared/src/Toaster/index.tsx
@@ -12,7 +12,7 @@ export interface ToastOptions {
   icon?: IconName | JSX.Element
   hideDismiss?: boolean
   key?: string
-  toasterProperties ?: IToasterProps
+  toasterProperties?: IToasterProps
   onDismiss?: (didTimeoutExpire: boolean) => void
 }
 
@@ -50,17 +50,15 @@ const warningOptions = {
   key: 'warning'
 }
 
-const selectToaster = (options ?: IToasterProps) =>
-{
+const selectToaster = (options?: IToasterProps) => {
   if(options){
     return Toaster.create(options)
-  }
-  else{
+  } else{
     return defaultToaster
   }
 }
 
-const dismiss = (key: string, options ?: IToasterProps) => {
+const dismiss = (key: string, options?: IToasterProps) => {
   if (!toastKeys[key]) {
     return
   }

--- a/packages/ui-shared/src/Toaster/index.tsx
+++ b/packages/ui-shared/src/Toaster/index.tsx
@@ -50,7 +50,7 @@ const warningOptions = {
   key: 'warning'
 }
 
-const selectToaster = (options?) => options ? Toaster.create(options) : defaultToaster
+const selectToaster = (options?: IToasterProps) => (options ? Toaster.create(options) : defaultToaster)
 
 const dismiss = (key: string, options?: IToasterProps) => {
   if (!toastKeys[key]) {
@@ -84,7 +84,7 @@ const showToast = (message: string | React.ReactElement, intent, options: ToastO
   }
 
   const showToast = () => {
-    dismiss(options.key! , options.toasterProps)
+    dismiss(options.key!, options.toasterProps)
 
     toastKeys[options.key!] = selectToaster(options.toasterProps).show({
       message: typeof message === 'string' ? lang(message) : message,

--- a/packages/ui-shared/src/Toaster/index.tsx
+++ b/packages/ui-shared/src/Toaster/index.tsx
@@ -1,4 +1,4 @@
-import { IconName, Intent, Position, Toaster } from '@blueprintjs/core'
+import { IconName, Intent, IToasterProps, Position, Toaster } from '@blueprintjs/core'
 import _ from 'lodash'
 
 import { lang } from '../translations'
@@ -12,10 +12,11 @@ export interface ToastOptions {
   icon?: IconName | JSX.Element
   hideDismiss?: boolean
   key?: string
+  toasterProperties ?: IToasterProps
   onDismiss?: (didTimeoutExpire: boolean) => void
 }
 
-const toaster = Toaster.create({ className: style.toaster, position: Position.BOTTOM })
+const defaultToaster = Toaster.create({ className: style.toaster, position: Position.BOTTOM })
 const toastKeys = {}
 
 const prepareMessage = (message: string | React.ReactElement, details?: string) =>
@@ -49,12 +50,22 @@ const warningOptions = {
   key: 'warning'
 }
 
-const dismiss = (key: string) => {
+const selectToaster = (options ?: IToasterProps) =>
+{
+  if(options){
+    return Toaster.create(options)
+  }
+  else{
+    return defaultToaster
+  }
+}
+
+const dismiss = (key: string, options ?: IToasterProps) => {
   if (!toastKeys[key]) {
     return
   }
 
-  toaster.dismiss(toastKeys[key])
+  selectToaster(options).dismiss(toastKeys[key])
 }
 
 const success = (message: string | React.ReactElement, details?: string, options?: ToastOptions) =>
@@ -81,9 +92,9 @@ const showToast = (message: string | React.ReactElement, intent, options: ToastO
   }
 
   const showToast = () => {
-    dismiss(options.key!)
+    dismiss(options.key! , options.toasterProperties)
 
-    toastKeys[options.key!] = toaster.show({
+    toastKeys[options.key!] = selectToaster(options.toasterProperties).show({
       message: typeof message === 'string' ? lang(message) : message,
       intent,
       timeout,


### PR DESCRIPTION
Made some UI modifications for the Toaster. Here are the before and after screenshots to detail the changes: 

Before: 


<img width="804" alt="Screen Shot 2021-06-30 at 11 58 14 AM" src="https://user-images.githubusercontent.com/68242902/123993482-74a39280-d99a-11eb-9743-5a05f12bdf0b.png">

After: 
<img width="1132" alt="Screen Shot 2021-06-30 at 10 55 18 AM" src="https://user-images.githubusercontent.com/68242902/123993106-2abaac80-d99a-11eb-8ef0-dc1445ef074e.png">
<img width="929" alt="Screen Shot 2021-06-30 at 10 55 34 AM" src="https://user-images.githubusercontent.com/68242902/123993120-2c847000-d99a-11eb-9cc7-07559ce0d2ed.png">
