### PR TITLE
fix(core): fix disk storage race condition

### DIFF
--- a/packages/studio-be/package.json
+++ b/packages/studio-be/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "@botpress/native-extensions": "0.0.1",
     "@apidevtools/json-schema-ref-parser": "^9.0.7",
-    "async-mutex": "^0.3.1",
     "axios": "^0.21.1",
     "bluebird": "^3.7.2",
     "bluebird-global": "^1.0.1",
@@ -53,6 +52,7 @@
     "plur": "^4.0.0",
     "portfinder": "^1.0.28",
     "pg": "^7.8.0",
+    "proper-lockfile": "^4.1.2",
     "reflect-metadata": "^0.1.13",
     "replace-in-file": "^4.1.1",
     "rimraf": "^3.0.2",
@@ -81,6 +81,7 @@
     "@types/joi": "^13.4.5",
     "@types/lodash": "4.14.123",
     "@types/node": "^12.13.1",
+    "@types/proper-lockfile": "^4.1.2",
     "@types/verror": "^1.10.3"
   }
 }

--- a/packages/studio-be/package.json
+++ b/packages/studio-be/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@botpress/native-extensions": "0.0.1",
     "@apidevtools/json-schema-ref-parser": "^9.0.7",
+    "async-mutex": "^0.3.1",
     "axios": "^0.21.1",
     "bluebird": "^3.7.2",
     "bluebird-global": "^1.0.1",

--- a/packages/studio-be/src/core/bpfs/drivers/disk-driver.ts
+++ b/packages/studio-be/src/core/bpfs/drivers/disk-driver.ts
@@ -16,7 +16,7 @@ import { BPError, FileRevision, StorageDriver } from '../'
 export class DiskStorageDriver implements StorageDriver {
   resolvePath = (p: string) => path.resolve(process.DATA_LOCATION, p)
 
-  private readonly lockfilePath = this.resolvePath(path.join('locks'))
+  private readonly lockfilePath = this.resolvePath('locks')
   private lockOptions = (file: string): lockfile.LockOptions => ({
     retries: {
       retries: 5,

--- a/packages/studio-be/src/core/bpfs/drivers/disk-driver.ts
+++ b/packages/studio-be/src/core/bpfs/drivers/disk-driver.ts
@@ -1,9 +1,10 @@
 import { DirectoryListingOptions } from 'botpress/sdk'
 import { forceForwardSlashes } from 'core/misc/utils'
+import crypto from 'crypto'
 import { WrapErrorsWith } from 'errors'
 import fse from 'fs-extra'
 import glob from 'glob'
-import { injectable } from 'inversify'
+import { injectable, postConstruct } from 'inversify'
 import _ from 'lodash'
 import path from 'path'
 import lockfile from 'proper-lockfile'
@@ -14,13 +15,26 @@ import { BPError, FileRevision, StorageDriver } from '../'
 @injectable()
 export class DiskStorageDriver implements StorageDriver {
   resolvePath = (p: string) => path.resolve(process.DATA_LOCATION, p)
-  private readonly lockOptions: lockfile.LockOptions = {
+
+  private readonly lockfilePath = this.resolvePath(path.join('locks'))
+  private lockOptions = (file: string): lockfile.LockOptions => ({
     retries: {
       retries: 5,
       factor: 3,
       minTimeout: 1 * 1000,
-      maxTimeout: 60 * 1000,
+      maxTimeout: 10 * 1000,
       randomize: true
+    },
+    lockfilePath: path.join(this.lockfilePath, `${file}.lock`)
+  })
+
+  @postConstruct()
+  async init() {
+    const isDirEmpty = async (dirname: string) => (await fse.readdir(dirname)).length === 0
+
+    const exists = await fse.pathExists(this.lockfilePath)
+    if ((exists && !(await isDirEmpty(this.lockfilePath))) || !exists) {
+      await fse.emptyDir(this.lockfilePath)
     }
   }
 
@@ -30,7 +44,7 @@ export class DiskStorageDriver implements StorageDriver {
       const filename = this.resolvePath(filePath)
       const folder = path.dirname(filename)
 
-      const release = await lockfile.lock(filename, this.lockOptions)
+      const release = await lockfile.lock(filename, this.lockOptions(this._hash(filename)))
       try {
         await fse.mkdirp(folder)
         await fse.writeFile(filename, content)
@@ -50,11 +64,11 @@ export class DiskStorageDriver implements StorageDriver {
     try {
       const filename = this.resolvePath(filePath)
 
-      const release = await lockfile.lock(filename, this.lockOptions)
+      const release = await lockfile.lock(filename, this.lockOptions(this._hash(filename)))
       try {
         return fse.readFile(filename)
       } finally {
-        release()
+        await release()
       }
     } catch (e) {
       if (e.code === 'ENOENT') {
@@ -184,6 +198,13 @@ export class DiskStorageDriver implements StorageDriver {
       .map(f => f.split('/')[0])
       .uniq()
       .value()
+  }
+
+  private _hash(str: string): string {
+    return crypto
+      .createHash('sha256')
+      .update(str)
+      .digest('hex')
   }
 
   private async _getGhostIgnorePatterns(ghostIgnorePath: string): Promise<string[]> {

--- a/packages/studio-be/src/core/bpfs/drivers/disk-driver.ts
+++ b/packages/studio-be/src/core/bpfs/drivers/disk-driver.ts
@@ -35,7 +35,7 @@ export class DiskStorageDriver implements StorageDriver {
         await fse.mkdirp(folder)
         await fse.writeFile(filename, content)
       } finally {
-        release()
+        await release()
       }
     } catch (e) {
       throw new VError(e, `[Disk Storage] Error upserting file "${filePath}"`)

--- a/packages/studio-be/src/core/bpfs/drivers/disk-driver.ts
+++ b/packages/studio-be/src/core/bpfs/drivers/disk-driver.ts
@@ -1,4 +1,3 @@
-import { Mutex } from 'async-mutex'
 import { DirectoryListingOptions } from 'botpress/sdk'
 import { forceForwardSlashes } from 'core/misc/utils'
 import { WrapErrorsWith } from 'errors'
@@ -7,6 +6,7 @@ import glob from 'glob'
 import { injectable } from 'inversify'
 import _ from 'lodash'
 import path from 'path'
+import lockfile from 'proper-lockfile'
 import { VError } from 'verror'
 
 import { BPError, FileRevision, StorageDriver } from '../'
@@ -14,7 +14,15 @@ import { BPError, FileRevision, StorageDriver } from '../'
 @injectable()
 export class DiskStorageDriver implements StorageDriver {
   resolvePath = (p: string) => path.resolve(process.DATA_LOCATION, p)
-  mutexes: { [filename: string]: Mutex } = {}
+  private readonly lockOptions: lockfile.LockOptions = {
+    retries: {
+      retries: 5,
+      factor: 3,
+      minTimeout: 1 * 1000,
+      maxTimeout: 60 * 1000,
+      randomize: true
+    }
+  }
 
   async upsertFile(filePath: string, content: string | Buffer): Promise<void>
   async upsertFile(filePath: string, content: string | Buffer, recordRevision: boolean = false): Promise<void> {
@@ -22,8 +30,7 @@ export class DiskStorageDriver implements StorageDriver {
       const filename = this.resolvePath(filePath)
       const folder = path.dirname(filename)
 
-      const mutex = this._getMutex(filename)
-      const release = await mutex.acquire()
+      const release = await lockfile.lock(filename, this.lockOptions)
       try {
         await fse.mkdirp(folder)
         await fse.writeFile(filename, content)
@@ -43,8 +50,7 @@ export class DiskStorageDriver implements StorageDriver {
     try {
       const filename = this.resolvePath(filePath)
 
-      const mutex = this._getMutex(filename)
-      const release = await mutex.acquire()
+      const release = await lockfile.lock(filename, this.lockOptions)
       try {
         return fse.readFile(filename)
       } finally {
@@ -169,14 +175,6 @@ export class DiskStorageDriver implements StorageDriver {
     } catch (e) {
       return []
     }
-  }
-
-  private _getMutex(filename: string) {
-    if (!this.mutexes[filename]) {
-      this.mutexes[filename] = new Mutex()
-    }
-
-    return this.mutexes[filename]
   }
 
   private _getBaseDirectories(files: string[]): string[] {

--- a/packages/studio-be/src/core/bpfs/drivers/disk-driver.ts
+++ b/packages/studio-be/src/core/bpfs/drivers/disk-driver.ts
@@ -1,6 +1,5 @@
 import { Mutex } from 'async-mutex'
 import { DirectoryListingOptions } from 'botpress/sdk'
-import { BPError } from 'core/dialog/errors'
 import { forceForwardSlashes } from 'core/misc/utils'
 import { WrapErrorsWith } from 'errors'
 import fse from 'fs-extra'
@@ -10,11 +9,11 @@ import _ from 'lodash'
 import path from 'path'
 import { VError } from 'verror'
 
-import { FileRevision, StorageDriver } from '../'
+import { BPError, FileRevision, StorageDriver } from '../'
 
 @injectable()
 export class DiskStorageDriver implements StorageDriver {
-  resolvePath = (p: string) => path.resolve(process.PROJECT_LOCATION, p)
+  resolvePath = (p: string) => path.resolve(process.DATA_LOCATION, p)
   mutexes: { [filename: string]: Mutex } = {}
 
   async upsertFile(filePath: string, content: string | Buffer): Promise<void>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1008,6 +1008,13 @@
   resolved "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
+"@types/proper-lockfile@^4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@types/proper-lockfile/-/proper-lockfile-4.1.2.tgz#49537cee7134055ee13a1833b76a1c298f39bb26"
+  integrity sha512-kd4LMvcnpYkspDcp7rmXKedn8iJSCoa331zRRamUp5oanKt/CefbEGPQP7G89enz7sKD4bvsr8mHSsC8j5WOvA==
+  dependencies:
+    "@types/retry" "*"
+
 "@types/puppeteer@*":
   version "5.4.3"
   resolved "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.3.tgz#cdca84aa7751d77448d8a477dbfa0af1f11485f2"
@@ -1081,6 +1088,11 @@
     "@types/prop-types" "*"
     "@types/scheduler" "*"
     csstype "^3.0.2"
+
+"@types/retry@*":
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.1.tgz#d8f1c0d0dc23afad6dc16a9e993a0865774b4065"
+  integrity sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==
 
 "@types/scheduler@*":
   version "0.16.1"
@@ -1867,13 +1879,6 @@ async-limiter@~1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
-
-async-mutex@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/async-mutex/-/async-mutex-0.3.1.tgz#7033af665f1c7cebed8b878267a43ba9e77c5f67"
-  integrity sha512-vRfQwcqBnJTLzVQo72Sf7KIUbcSUP5hNchx6udI1U6LuPQpfePgdjJzlCe76yFZ8pxlLjn9lwcl/Ya0TSOv0Tw==
-  dependencies:
-    tslib "^2.1.0"
 
 async-settle@^1.0.0:
   version "1.0.0"
@@ -10696,6 +10701,15 @@ prop-types@15.7.2, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, 
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
+proper-lockfile@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/proper-lockfile/-/proper-lockfile-4.1.2.tgz#c8b9de2af6b2f1601067f98e01ac66baa223141f"
+  integrity sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    retry "^0.12.0"
+    signal-exit "^3.0.2"
+
 proxy-addr@~2.0.5:
   version "2.0.7"
   resolved "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
@@ -11886,6 +11900,11 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
+
+retry@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
+  integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
 
 reusify@^1.0.4:
   version "1.0.4"
@@ -13444,11 +13463,6 @@ tslib@^1.8.1, tslib@^1.9.2, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^2.1.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
-  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
 tslib@~1.13.0:
   version "1.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1868,6 +1868,13 @@ async-limiter@~1.0.0:
   resolved "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
+async-mutex@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/async-mutex/-/async-mutex-0.3.1.tgz#7033af665f1c7cebed8b878267a43ba9e77c5f67"
+  integrity sha512-vRfQwcqBnJTLzVQo72Sf7KIUbcSUP5hNchx6udI1U6LuPQpfePgdjJzlCe76yFZ8pxlLjn9lwcl/Ya0TSOv0Tw==
+  dependencies:
+    tslib "^2.1.0"
+
 async-settle@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/async-settle/-/async-settle-1.0.0.tgz#1d0a914bb02575bec8a8f3a74e5080f72b2c0c6b"
@@ -13437,6 +13444,11 @@ tslib@^1.8.1, tslib@^1.9.2, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
+  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
 tslib@~1.13.0:
   version "1.13.0"


### PR DESCRIPTION
This PR fixes an issue where a race condition may happen on slow storage disks when using BPFS_STORAGE=disk.

Related PR in main repo: https://github.com/botpress/botpress/pull/5162

The issue is similar to what is shown in this thread: https://stackoverflow.com/questions/57303480/writing-to-a-file-and-simultaneously-reading-it-to-create-a-race-condition-in-no

### TODO

- [x] More tests
- [x] Make sure to delete all locks on server start

### Screenshots

![Screenshot from 2021-06-29 10-32-40](https://user-images.githubusercontent.com/9640576/124297926-a303a800-db29-11eb-8b7b-c443a89447a3.png)

![Screenshot from 2021-07-02 10-20-16](https://user-images.githubusercontent.com/9640576/124297955-af880080-db29-11eb-9031-59ab52585f9c.png)

### Steps to reproduce the issue:

1. Use a slow HDD or a slow/old USB stick.
2. Mount out/bp/data to the USB device (or HDD).
3. Start Botpress
4. Create an empty bot and add two text content-element to the entry node.
5. Open the Chrome inspector.
6. Move the entry node so that it sends a flow update request.
7. Open Postman and replicate the flow update POST request
8. Use Postman's runner (bottom right) to execute the request ~1000 times
9. You should see the error popup (see screenshots for example)
