### PR TITLE
chore(studio): Right indent text in Arabic language

### DIFF
--- a/packages/studio-ui/src/web/components/SmartInput/index.tsx
+++ b/packages/studio-ui/src/web/components/SmartInput/index.tsx
@@ -139,11 +139,10 @@ class SmartInput extends React.Component<ConnectedProps, State> {
     if (this.props.singleLine) {
       plugins.push(createSingleLinePlugin())
     }
-
     return (
       <div
         className={cx(style.editor, this.props.className)}
-        style={this.props.contentLang === 'ar' ? { direction: 'rtl' } : null}
+        style={{ paddingRight: '32px !important', direction: this.props.contentLang === 'ar' ? 'rtl' : 'ltr' }}
         onClick={this.focus}
       >
         <Editor

--- a/packages/studio-ui/src/web/components/SmartInput/index.tsx
+++ b/packages/studio-ui/src/web/components/SmartInput/index.tsx
@@ -26,7 +26,7 @@ interface ExposedProps {
 const { hasCommandModifier } = KeyBindingUtil
 const A_KEY = 65
 
-type ConnectedProps = ExposedProps & { hints: any[] }
+type ConnectedProps = ExposedProps & { hints: any[]; contentLang: string }
 
 interface State {
   beforeContentStateText?: string
@@ -141,7 +141,11 @@ class SmartInput extends React.Component<ConnectedProps, State> {
     }
 
     return (
-      <div className={cx(style.editor, this.props.className)} onClick={this.focus}>
+      <div
+        className={cx(style.editor, this.props.className)}
+        style={this.props.contentLang === 'ar' ? { direction: 'rtl' } : null}
+        onClick={this.focus}
+      >
         <Editor
           stripPastedStyles
           placeholder={this.placeholder}
@@ -170,7 +174,7 @@ class SmartInput extends React.Component<ConnectedProps, State> {
 }
 
 const mapDispatchToProps = { refreshHints }
-const mapStateToProps = ({ hints: { inputs } }) => ({ hints: inputs })
+const mapStateToProps = ({ hints: { inputs }, language: { contentLang } }) => ({ hints: inputs, contentLang })
 const ConnectedSmartInput = connect(mapStateToProps, mapDispatchToProps)(SmartInput)
 
 // Passing store explicitly since this component may be imported from another botpress-module


### PR DESCRIPTION
Currently the text editor aligns the text to the left for RTL languages, switching that to the right when the arabic language is selected