### PR TITLE
fix(studio): don't open node props when moving it

### DIFF
--- a/packages/studio-ui/src/web/views/FlowBuilder/diagram/index.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/diagram/index.tsx
@@ -232,7 +232,7 @@ class Diagram extends Component<Props> {
     this.props.fetchFlows()
     this.setState({ expandedNodes: getExpandedNodes() })
 
-    ReactDOM.findDOMNode(this.diagramWidget).addEventListener('click', this.onDiagramClick)
+    ReactDOM.findDOMNode(this.diagramWidget).addEventListener('click', this. onDiagramClick)
     ReactDOM.findDOMNode(this.diagramWidget).addEventListener('mousedown', this.onMouseDown)
     ReactDOM.findDOMNode(this.diagramWidget).addEventListener('dblclick', this.onDiagramDoubleClick)
     document.getElementById('diagramContainer').addEventListener('keydown', this.onKeyDown)
@@ -545,6 +545,7 @@ class Diagram extends Component<Props> {
 
   onDiagramClick = (event: MouseEvent) => {
     const selectedNode = this.manager.getSelectedNode() as BlockModel
+    console.log('SELECTED NODE', selectedNode.id)
     const currentNode = this.props.currentFlowNode
     const target = this.diagramWidget.getMouseElement(event)
 
@@ -580,6 +581,7 @@ class Diagram extends Component<Props> {
       }
       this.props.updateFlowNode(nodesToMove)
       Object.assign(selectedNode, { oldX: selectedNode.x, oldY: selectedNode.y })
+      this.props.closeFlowNodeProps()
     }
 
     this.checkForLinksUpdate()

--- a/packages/studio-ui/src/web/views/FlowBuilder/diagram/index.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/diagram/index.tsx
@@ -562,7 +562,7 @@ class Diagram extends Component<Props> {
       this.handleContextMenu(event as any)
     }
 
-    if (this.canTargetOpenInspector(target)) {
+    if (this.canTargetOpenInspector(target) && selectedNode && selectedNode.oldX === selectedNode.x && selectedNode.oldY === selectedNode.y) {
       this.props.openFlowNodeProps()
     }
 
@@ -580,7 +580,6 @@ class Diagram extends Component<Props> {
       }
       this.props.updateFlowNode(nodesToMove)
       Object.assign(selectedNode, { oldX: selectedNode.x, oldY: selectedNode.y })
-      this.props.closeFlowNodeProps()
     }
 
     this.checkForLinksUpdate()

--- a/packages/studio-ui/src/web/views/FlowBuilder/diagram/index.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/diagram/index.tsx
@@ -562,7 +562,12 @@ class Diagram extends Component<Props> {
       this.handleContextMenu(event as any)
     }
 
-    if (this.canTargetOpenInspector(target) && selectedNode && selectedNode.oldX === selectedNode.x && selectedNode.oldY === selectedNode.y) {
+    if (
+      this.canTargetOpenInspector(target) &&
+      selectedNode &&
+      selectedNode.oldX === selectedNode.x &&
+      selectedNode.oldY === selectedNode.y
+    ) {
       this.props.openFlowNodeProps()
     }
 

--- a/packages/studio-ui/src/web/views/FlowBuilder/diagram/index.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/diagram/index.tsx
@@ -232,7 +232,7 @@ class Diagram extends Component<Props> {
     this.props.fetchFlows()
     this.setState({ expandedNodes: getExpandedNodes() })
 
-    ReactDOM.findDOMNode(this.diagramWidget).addEventListener('click', this. onDiagramClick)
+    ReactDOM.findDOMNode(this.diagramWidget).addEventListener('click', this.onDiagramClick)
     ReactDOM.findDOMNode(this.diagramWidget).addEventListener('mousedown', this.onMouseDown)
     ReactDOM.findDOMNode(this.diagramWidget).addEventListener('dblclick', this.onDiagramDoubleClick)
     document.getElementById('diagramContainer').addEventListener('keydown', this.onKeyDown)
@@ -545,7 +545,6 @@ class Diagram extends Component<Props> {
 
   onDiagramClick = (event: MouseEvent) => {
     const selectedNode = this.manager.getSelectedNode() as BlockModel
-    console.log('SELECTED NODE', selectedNode.id)
     const currentNode = this.props.currentFlowNode
     const target = this.diagramWidget.getMouseElement(event)
 


### PR DESCRIPTION
There was an annoying issue - when a user moves a node, it opens up a node props on the right. I added a check - if the note has been moving or not, and so I disable the props in the first case.