### PR TITLE
feat(studio): Custom Icon for Conversation End Flows

### DIFF
--- a/packages/studio-ui/src/web/components/Shared/Utils/index.tsx
+++ b/packages/studio-ui/src/web/components/Shared/Utils/index.tsx
@@ -21,6 +21,8 @@ export const getFlowLabel = (name: string) => {
     return 'Error handling'
   } else if (name === 'timeout') {
     return 'Timeout'
+  } else if (name === 'conversation_end') {
+    return 'Conversation End'
   } else {
     return name
   }

--- a/packages/studio-ui/src/web/translations/en.json
+++ b/packages/studio-ui/src/web/translations/en.json
@@ -366,6 +366,7 @@
         "renamingAndDeletingDisabled": "Renaming and Deleting flows is disabled",
         "somebodyIsEditing": "Somebody is editing another flow",
         "whenDiscussionTimeouts": "When a discussion timeouts (user doesn't answer in the configured timeframe) he will be redirected here.",
+        "whenConversationEnds": "When a conversation ends (no transition) he will be redirected here.",
         "whenErrorEncountered": "When an error is encountered in the flow, the user is redirected here"
       },
       "topic": "Topic",

--- a/packages/studio-ui/src/web/translations/es.json
+++ b/packages/studio-ui/src/web/translations/es.json
@@ -366,6 +366,7 @@
         "renamingAndDeletingDisabled": "Cambiar el nombre y eliminar flujos está deshabilitado",
         "somebodyIsEditing": "Alguien está editando otro flujo",
         "whenDiscussionTimeouts": "Cuando se espera un tiempo de espera de discusión (el usuario no responde en el marco temporal configurado) será redirigido aquí.",
+        "whenConversationEnds": "Cuando finalice una conversación (sin transición), será redirigido aquí.",
         "whenErrorEncountered": "Cuando se encuentra un error en el flujo, el usuario se redirige aquí"
       },
       "topic": "Tema",

--- a/packages/studio-ui/src/web/translations/fr.json
+++ b/packages/studio-ui/src/web/translations/fr.json
@@ -364,6 +364,7 @@
         "renamingAndDeletingDisabled": "Renommer et supprimer des flows est désactivé",
         "somebodyIsEditing": "Quelqu'un modifie un autre flow",
         "whenDiscussionTimeouts": "Lors d'un délai d'attente de discussion (l'utilisateur ne répond pas dans le délai configuré), il sera redirigé ici.",
+        "whenConversationEnds": "Lorsqu'une conversation se termine (pas de transition), il sera redirigé ici.",
         "whenErrorEncountered": "Lorsqu'une erreur est rencontrée dans le flux, l'utilisateur est redirigé ici"
       },
       "topic": "Sujet",

--- a/packages/studio-ui/src/web/views/FlowBuilder/sidePanelFlows/FlowsList.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/sidePanelFlows/FlowsList.tsx
@@ -11,6 +11,7 @@ export const FLOW_ICON = 'document'
 export const MAIN_FLOW_ICON = 'flow-end'
 export const ERROR_FLOW_ICON = 'pivot'
 export const TIMEOUT_ICON = 'time'
+export const CONVERSATION_END_ICON = 'stop'
 
 const lockedFlows = ['main.flow.json', 'error.flow.json']
 

--- a/packages/studio-ui/src/web/views/FlowBuilder/sidePanelFlows/util.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/sidePanelFlows/util.tsx
@@ -5,7 +5,14 @@ import find from 'lodash/find'
 import React from 'react'
 import { getFlowLabel, reorderFlows } from '~/components/Shared/Utils'
 
-import { ERROR_FLOW_ICON, FLOW_ICON, FOLDER_ICON, MAIN_FLOW_ICON, TIMEOUT_ICON } from './FlowsList'
+import {
+  ERROR_FLOW_ICON,
+  FLOW_ICON,
+  FOLDER_ICON,
+  MAIN_FLOW_ICON,
+  TIMEOUT_ICON,
+  CONVERSATION_END_ICON
+} from './FlowsList'
 
 /**
  * Returns a different display for special flows.
@@ -45,6 +52,19 @@ const getFlowInfo = (flowId: string, flowName: string) => {
       label: (
         <Tooltip
           content={<span>{lang.tr('studio.flow.whenDiscussionTimeouts')}</span>}
+          hoverOpenDelay={500}
+          position={Position.BOTTOM}
+        >
+          <strong>{getFlowLabel(flowName)}</strong>
+        </Tooltip>
+      )
+    }
+  } else if (flowId === 'conversation_end') {
+    return {
+      icon: CONVERSATION_END_ICON,
+      label: (
+        <Tooltip
+          content={<span>{lang.tr('studio.flow.toolbar.whenConversationEnds')}</span>}
           hoverOpenDelay={500}
           position={Position.BOTTOM}
         >


### PR DESCRIPTION
Should be merged so the new flow has a custom icon like the others.

![image](https://user-images.githubusercontent.com/13484138/126844002-6e67bc6b-067c-4cb8-8e52-dfa93dd66107.png)

Related to this PR https://github.com/botpress/botpress/pull/5215