### PR TITLE
fix(studio): guided tour highlighting restored and more

### DIFF
--- a/packages/studio-ui/src/web/components/Layout/BottomPanel/Debugger/components/Intent.tsx
+++ b/packages/studio-ui/src/web/components/Layout/BottomPanel/Debugger/components/Intent.tsx
@@ -40,7 +40,7 @@ const navigateToIntentDefinition = (intent: string, isQna: boolean) => () => {
   if (isQna) {
     url = `/modules/qna?id=${intent}`
   } else {
-    url = intent === 'none' ? '/modules/nlu' : `/modules/nlu?type=intent&id=${intent}`
+    url = intent === 'none' ? '/nlu' : `/nlu?type=intent&id=${intent}`
   }
   window.parent.postMessage({ action: 'navigate-url', payload: url }, '*')
 }

--- a/packages/studio-ui/src/web/components/Layout/GuidedTour.jsx
+++ b/packages/studio-ui/src/web/components/Layout/GuidedTour.jsx
@@ -25,7 +25,7 @@ export default class GuidedTour extends React.Component {
         content: 'Welcome to Botpress! This is a quick tour of the most important features.'
       },
       {
-        selector: '.Pane.Pane1',
+        selector: '#bp-menu_flows',
         content:
           'The Flows screen is the main interface where you can see and edit your conversation flows.'
       },

--- a/packages/studio-ui/src/web/components/Layout/GuidedTour.jsx
+++ b/packages/studio-ui/src/web/components/Layout/GuidedTour.jsx
@@ -25,27 +25,31 @@ export default class GuidedTour extends React.Component {
         content: 'Welcome to Botpress! This is a quick tour of the most important features.'
       },
       {
-        selector: '#bp-menu_qna',
-        content: 'The QnA module is great for easily adding knowledge to you bot as "Question & Answer" pairs.'
+        selector: '.Pane.Pane1',
+        content:
+          'The Flows screen is the main interface where you can see and edit your conversation flows.'
       },
       {
         selector: '#bp-menu_nlu',
         content:
-          'The "Understanding" screen will allow you to understand more complex user queries (Intents) and extract structured information (Entities).'
+          'The Natural Language Understanding screen is where you will give example sentences to train the AI for understanding humans.'
       },
       {
-        selector: '#bp-menu_Flows',
-        content:
-          'The "Flows" screen is the main interface. Using this tool, you can go beyond static responses by designing more complex, multi-turn dialogs.'
+        selector: '#bp-menu_qna',
+        content: 'Anyone on your team can easily add questions and answers to the Q&A page.'
       },
       {
         selector: '#statusbar_emulator',
         content:
-          'When making changes to your bot, you will use the Emulator to chat with your bot and debug your conversations.'
+          'Use the emulator to try out your bot at any time! You can also use it to troubleshoot.'
       },
       {
-        selector: '#statusbar_switchbot',
+        selector: '#all-bots-navigation',
         content: 'Finally, this button will allow you to return to the administration panel or switch bot.'
+      },
+      {
+        selector: '',
+        content: 'All done. Enjoy building bots! For more information, please refer to the guide on botpress.com/docs'
       }
     ]
 
@@ -54,7 +58,7 @@ export default class GuidedTour extends React.Component {
         steps={steps}
         isOpen={this.props.isDisplayed}
         onRequestClose={this.props.onToggle}
-        lastStepNextButton={<Button>Let's get to work!</Button>}
+        showNumber={false}
       />
     )
   }

--- a/packages/studio-ui/src/web/components/Layout/GuidedTour.jsx
+++ b/packages/studio-ui/src/web/components/Layout/GuidedTour.jsx
@@ -44,7 +44,7 @@ export default class GuidedTour extends React.Component {
           'Use the emulator to try out your bot at any time! You can also use it to troubleshoot.'
       },
       {
-        selector: '#all-bots-navigation',
+        selector: '#bp-menu_admin',
         content: 'Finally, this button will allow you to return to the administration panel or switch bot.'
       },
       {

--- a/packages/studio-ui/src/web/components/Layout/Sidebar.tsx
+++ b/packages/studio-ui/src/web/components/Layout/Sidebar.tsx
@@ -96,7 +96,7 @@ const Sidebar: FC<Props> = props => {
 
   return (
     <aside className={classnames(style.sidebar, 'bp-sidebar')}>
-      <a href="admin/" className={classnames(style.logo, 'bp-logo')}>
+      <a href="admin/" className={classnames(style.logo, 'bp-logo')} id="all-bots-navigation">
         <img width="19" src="assets/studio/ui/public/img/logo-icon.svg" alt="Botpress Logo" />
       </a>
       <ul className={classnames('nav')}>

--- a/packages/studio-ui/src/web/components/Layout/Sidebar.tsx
+++ b/packages/studio-ui/src/web/components/Layout/Sidebar.tsx
@@ -96,7 +96,7 @@ const Sidebar: FC<Props> = props => {
 
   return (
     <aside className={classnames(style.sidebar, 'bp-sidebar')}>
-      <a href="admin/" className={classnames(style.logo, 'bp-logo')} id="all-bots-navigation">
+      <a href="admin/" className={classnames(style.logo, 'bp-logo')} id="bp-menu_admin">
         <img width="19" src="assets/studio/ui/public/img/logo-icon.svg" alt="Botpress Logo" />
       </a>
       <ul className={classnames('nav')}>

--- a/packages/studio-ui/src/web/components/Layout/Toolbar/index.tsx
+++ b/packages/studio-ui/src/web/components/Layout/Toolbar/index.tsx
@@ -67,6 +67,7 @@ const Toolbar: FC<Props> = props => {
             <button
               className={classNames(style.item, style.itemSpacing, { [style.active]: isEmulatorOpen })}
               onClick={onToggleEmulator}
+              id="statusbar_emulator"
             >
               <Icon color="#1a1e22" icon="chat" iconSize={16} />
               <span className={style.label}>{lang.tr('toolbar.emulator')}</span>

--- a/packages/studio-ui/src/web/components/Layout/index.tsx
+++ b/packages/studio-ui/src/web/components/Layout/index.tsx
@@ -178,7 +178,7 @@ const Layout: FC<Props> = (props: Props) => {
     'go-module-qna': () => gotoUrl('/modules/qna'),
     'go-module-testing': () => gotoUrl('/modules/testing'),
     'go-module-analytics': () => gotoUrl('/modules/analytics'),
-    'go-understanding': () => gotoUrl('/modules/nlu'),
+    'go-understanding': () => gotoUrl('/nlu'),
     'toggle-inspect': props.toggleInspector
   }
 

--- a/packages/studio-ui/src/web/translations/en.json
+++ b/packages/studio-ui/src/web/translations/en.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "additionalDetails": "Additionails Details",
+    "additionalDetails": "Additional Details",
     "avatarAndCover": "Avatar & Cover picture",
     "avatarUploadSuccess": "The bot avatar has been uploaded successfully. You need to save the form in order for the changes to take effect.",
     "botAvatar": "Bot Avatar",

--- a/packages/studio-ui/src/web/views/FlowBuilder/diagram/index.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/diagram/index.tsx
@@ -404,7 +404,14 @@ class Diagram extends Component<Props> {
           </Fragment>
         )}
 
-        <MenuItem tagName="button" text={lang.tr('skills')} icon="add" onClick={(e)=>{e.stopPropagation()}}>
+        <MenuItem
+          tagName="button"
+          text={lang.tr('skills')}
+          icon="add"
+          onClick={e => {
+            e.stopPropagation()
+          }}
+        >
           {this.props.skills.map(skill => (
             <MenuItem
               key={skill.id}

--- a/packages/studio-ui/src/web/views/FlowBuilder/diagram/index.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/diagram/index.tsx
@@ -404,7 +404,7 @@ class Diagram extends Component<Props> {
           </Fragment>
         )}
 
-        <MenuItem tagName="button" text={lang.tr('skills')} icon="add">
+        <MenuItem tagName="button" text={lang.tr('skills')} icon="add" onClick={(e)=>{e.stopPropagation()}}>
           {this.props.skills.map(skill => (
             <MenuItem
               key={skill.id}


### PR DESCRIPTION
Guided tour now highlights correct array. It was highlighting nothing for a few nodes and staying in the middle. I removed the bubble, and updated the text to make it slightly less challenging to read. 
![image](https://user-images.githubusercontent.com/87815239/128415326-b6d945bf-e3e5-4a65-ab73-d0a23b94cf79.png)

When right clicking in the flow UI, then clicking on the "skill" submenu button, the menu would close. This is a problem when you move around / click around too fast. 
![image](https://user-images.githubusercontent.com/87815239/128414896-0a078b5b-069b-431b-8e8e-2f343734fe5a.png)
This no longer happens. :)

Finally, there was a soft-crash happening when the user clicked the top intents 
![image](https://user-images.githubusercontent.com/87815239/128415479-f8a224fd-09c8-47a0-b498-5b39019b58b9.png)

It now redirects as it should. 