### PR TITLE
fix(studio) content picker confusion

### DIFF
--- a/packages/studio-ui/src/web/components/Content/Select/Widget.tsx
+++ b/packages/studio-ui/src/web/components/Content/Select/Widget.tsx
@@ -118,7 +118,6 @@ class ContentPickerWidget extends Component<Props> {
       <ControlGroup fill>
         <div
           className={style.clickableInput}
-          style={{ display: 'flex', flexDirection: 'row'}}
           onClick={() => (contentItem ? this.editItem() : window.botpress.pickContent({ contentType }, this.onChange))}
         >
           <InputGroup

--- a/packages/studio-ui/src/web/components/Content/Select/Widget.tsx
+++ b/packages/studio-ui/src/web/components/Content/Select/Widget.tsx
@@ -116,14 +116,19 @@ class ContentPickerWidget extends Component<Props> {
 
     return (
       <ControlGroup fill>
-        <InputGroup
-          placeholder={placeholder}
-          value={textContent}
-          disabled
-          id={inputId || ''}
-          className={style.contentInput}
-        />
-        {contentItem && <Button icon="edit" onClick={this.editItem} className={Classes.FIXED} />}
+        <div
+          style={{ display: 'flex', flexDirection: 'row'}}
+          onClick={() => (contentItem ? this.editItem() : window.botpress.pickContent({ contentType }, this.onChange))}
+        >
+          <InputGroup
+            placeholder={placeholder}
+            value={textContent}
+            disabled
+            id={inputId || ''}
+            className={style.contentInput}
+          />
+          {contentItem && <Button icon="edit" className={Classes.FIXED} />}
+        </div>
         <Button
           icon="folder-open"
           onClick={() => window.botpress.pickContent({ contentType }, this.onChange)}

--- a/packages/studio-ui/src/web/components/Content/Select/Widget.tsx
+++ b/packages/studio-ui/src/web/components/Content/Select/Widget.tsx
@@ -117,6 +117,7 @@ class ContentPickerWidget extends Component<Props> {
     return (
       <ControlGroup fill>
         <div
+          className={style.clickableInput}
           style={{ display: 'flex', flexDirection: 'row'}}
           onClick={() => (contentItem ? this.editItem() : window.botpress.pickContent({ contentType }, this.onChange))}
         >

--- a/packages/studio-ui/src/web/components/Content/Select/index.tsx
+++ b/packages/studio-ui/src/web/components/Content/Select/index.tsx
@@ -320,7 +320,7 @@ class SelectContent extends Component<Props, State> {
               key={i}
               onClick={() => this.setState({ newItemCategory: category, newItemData: null })}
               className={`list-group-item list-group-item-action ${style.createItem} ${
-                hasSearchResults === false && i === this.state.activeItemIndex ? 'active' : ''
+                !hasSearchResults && i === this.state.activeItemIndex ? 'active' : ''
               }`}
             >
               {lang.tr('studio.content.createNew', { title: lang.tr(category.title) })}

--- a/packages/studio-ui/src/web/components/Content/Select/index.tsx
+++ b/packages/studio-ui/src/web/components/Content/Select/index.tsx
@@ -298,7 +298,7 @@ class SelectContent extends Component<Props, State> {
       }
     }
 
-    const thereIsASearchResult = this.props.contentItems.length > 0
+    const hasSearchResults = this.props.contentItems.length > 0
 
     return (
       <div>
@@ -320,7 +320,7 @@ class SelectContent extends Component<Props, State> {
               key={i}
               onClick={() => this.setState({ newItemCategory: category, newItemData: null })}
               className={`list-group-item list-group-item-action ${style.createItem} ${
-                thereIsASearchResult ? '' : i === this.state.activeItemIndex ? 'active' : ''
+                hasSearchResults === false && i === this.state.activeItemIndex ? 'active' : ''
               }`}
             >
               {lang.tr('studio.content.createNew', { title: lang.tr(category.title) })}

--- a/packages/studio-ui/src/web/components/Content/Select/index.tsx
+++ b/packages/studio-ui/src/web/components/Content/Select/index.tsx
@@ -249,6 +249,16 @@ class SelectContent extends Component<Props, State> {
     return `${lang.tr('search')} ${lang.tr(title)} (${this.props.contentItems?.length})`
   }
 
+  openNewEditor = category => {
+    let newItemData = null
+
+    if (category?.id === 'builtin_text') {
+      const textLangKey = `text$${this.props.contentLang}`
+      newItemData = { [textLangKey]: this.state.searchTerm }
+    }
+    this.setState({ newItemCategory: category, newItemData })
+  }
+
   onKeyDown = event => {
     if (event.key === 'Enter') {
       // open first active search
@@ -257,7 +267,7 @@ class SelectContent extends Component<Props, State> {
       }
       if (this.props.contentItems) {
         const category = this.getVisibleCategories()[0]
-        this.setState({ newItemCategory: category, newItemData: null })
+        this.openNewEditor(category)
       }
     }
   }
@@ -318,7 +328,7 @@ class SelectContent extends Component<Props, State> {
           {categories.map((category, i) => (
             <a
               key={i}
-              onClick={() => this.setState({ newItemCategory: category, newItemData: null })}
+              onClick={() => this.openNewEditor(category)}
               className={`list-group-item list-group-item-action ${style.createItem} ${
                 !hasSearchResults && i === this.state.activeItemIndex ? 'active' : ''
               }`}

--- a/packages/studio-ui/src/web/components/Content/Select/index.tsx
+++ b/packages/studio-ui/src/web/components/Content/Select/index.tsx
@@ -249,6 +249,19 @@ class SelectContent extends Component<Props, State> {
     return `${lang.tr('search')} ${lang.tr(title)} (${this.props.contentItems?.length})`
   }
 
+  onKeyDown = event => {
+    if (event.key === 'Enter') {
+      // open first active search
+      if (this.props.contentItems.length > 0) {
+        return this.handlePick(this.props.contentItems[0])
+      }
+      if (this.props.contentItems) {
+        const category = this.getVisibleCategories()[0]
+        this.setState({ newItemCategory: category, newItemData: null })
+      }
+    }
+  }
+
   renderMainBody() {
     const categories = this.getVisibleCategories()
 
@@ -285,6 +298,8 @@ class SelectContent extends Component<Props, State> {
       }
     }
 
+    const thereIsASearchResult = this.props.contentItems.length > 0
+
     return (
       <div>
         {this.renderCurrentCategoryInfo()}
@@ -296,6 +311,7 @@ class SelectContent extends Component<Props, State> {
           onChange={this.onSearchChange}
           autoFocus
           value={this.state.searchTerm}
+          onKeyDown={this.onKeyDown}
         />
         <hr />
         <div className="list-group">
@@ -303,7 +319,9 @@ class SelectContent extends Component<Props, State> {
             <a
               key={i}
               onClick={() => this.setState({ newItemCategory: category, newItemData: null })}
-              className={`list-group-item list-group-item-action ${style.createItem}`}
+              className={`list-group-item list-group-item-action ${style.createItem} ${
+                thereIsASearchResult ? '' : i === this.state.activeItemIndex ? 'active' : ''
+              }`}
             >
               {lang.tr('studio.content.createNew', { title: lang.tr(category.title) })}
             </a>

--- a/packages/studio-ui/src/web/components/Content/Select/style.scss
+++ b/packages/studio-ui/src/web/components/Content/Select/style.scss
@@ -43,3 +43,8 @@
 .imagePreview {
   height: 16px;
 }
+
+.clickableInput {
+  display: flex; 
+  flex-direction: row;
+}

--- a/packages/studio-ui/src/web/components/Content/Select/style.scss
+++ b/packages/studio-ui/src/web/components/Content/Select/style.scss
@@ -29,7 +29,7 @@
   padding: 20px 20px 0;
 
   :global(.list-group) {
-    margin-bottom: 0
+    margin-bottom: 0;
   }
 }
 
@@ -37,6 +37,7 @@
   input {
     color: #000 !important;
   }
+  flex: 1;
 }
 
 .imagePreview {

--- a/packages/studio-ui/src/web/components/Content/Select/style.scss.d.ts
+++ b/packages/studio-ui/src/web/components/Content/Select/style.scss.d.ts
@@ -3,6 +3,7 @@
 interface CssExports {
   'actionBtn': string;
   'body': string;
+  'clickableInput': string;
   'contentInput': string;
   'createItem': string;
   'editButton': string;


### PR DESCRIPTION
I'm not trying to redo the whole content picker because that would take a lot of time. 
This aims only to get rid of the issue I got where I was writing text, then "create new text" appears greyed out, and I subconsciously decided it was created, then clicked x and nothing appeared. :(

The fix lies in adding the "active" state to "create new ${content_type}" when there are no search results, to make it more obvious, and having the "enter" key create or select whatever is active
![Screen Shot 2021-08-06 at 2 42 36 PM](https://user-images.githubusercontent.com/87815239/128558593-0bfd4ada-488c-4cc1-9747-a32cd8287214.png)

This also makes it so clicking the greyed out bar acts as create / update button, not just the icon, because I was clicking that too!
![Screen Shot 2021-08-06 at 2 53 04 PM](https://user-images.githubusercontent.com/87815239/128558484-b88a70a5-db54-4e39-b265-f1ea320fd6b1.png)
