### PR TITLE
feat(studio): Swapped flow and content buttons for good UX

### DIFF
--- a/packages/studio-ui/src/web/components/Layout/Sidebar.tsx
+++ b/packages/studio-ui/src/web/components/Layout/Sidebar.tsx
@@ -17,18 +17,18 @@ type Props = StateProps & RouteComponentProps
 
 const BASIC_MENU_ITEMS = [
   {
-    id: 'content',
-    name: lang.tr('content'),
-    path: '/content',
-    rule: { res: 'bot.content', op: 'read' },
-    icon: 'description'
-  },
-  {
     id: 'flows',
     name: lang.tr('flows'),
     path: '/flows',
     rule: { res: 'bot.flows', op: 'read' },
     icon: 'page-layout'
+  },
+    {
+    id: 'content',
+    name: lang.tr('content'),
+    path: '/content',
+    rule: { res: 'bot.content', op: 'read' },
+    icon: 'description'
   },
   {
     id: 'nlu',


### PR DESCRIPTION
Users often tend to navigate to 'content' instead of 'flow' as a default human reflex.
Since "Flow" is our main working entity in studio, swapping these items will improve UX by making first item as "Flows"