### PR TITLE
fix: Swapped flow and content menu items in side menu

### DIFF
--- a/packages/studio-ui/src/web/components/Layout/Sidebar.tsx
+++ b/packages/studio-ui/src/web/components/Layout/Sidebar.tsx
@@ -17,18 +17,18 @@ type Props = StateProps & RouteComponentProps
 
 const BASIC_MENU_ITEMS = [
   {
-    id: 'content',
-    name: lang.tr('content'),
-    path: '/content',
-    rule: { res: 'bot.content', op: 'read' },
-    icon: 'description'
-  },
-  {
     id: 'flows',
     name: lang.tr('flows'),
     path: '/flows',
     rule: { res: 'bot.flows', op: 'read' },
     icon: 'page-layout'
+  },
+    {
+    id: 'content',
+    name: lang.tr('content'),
+    path: '/content',
+    rule: { res: 'bot.content', op: 'read' },
+    icon: 'description'
   },
   {
     id: 'nlu',

--- a/packages/studio-ui/src/web/components/Layout/Sidebar.tsx
+++ b/packages/studio-ui/src/web/components/Layout/Sidebar.tsx
@@ -23,7 +23,7 @@ const BASIC_MENU_ITEMS = [
     rule: { res: 'bot.flows', op: 'read' },
     icon: 'page-layout'
   },
-    {
+  {
     id: 'content',
     name: lang.tr('content'),
     path: '/content',


### PR DESCRIPTION
Users often tend to navigate to 'content' instead of 'flow' as a default human reflex.
Since "Flow" is our main working entity in studio, swapping these items will improve UX by making first item as "Flows"
![sidebar_icon_swap-01](https://user-images.githubusercontent.com/88099328/128925402-ab7007cd-2515-4a2e-a2e4-f5bc788f00c0.jpg)

