### PR TITLE
Reverts overflow behavior. Fix overflowing content

### DIFF
--- a/packages/ui-shared/src/Dialog/style.scss
+++ b/packages/ui-shared/src/Dialog/style.scss
@@ -6,6 +6,10 @@
   max-height: 90%;
   background-color: white !important;
 
+  :global(.bp3-dialog-body){
+    overflow: auto;
+  }
+
   :global {
     .bp3-button {
       transition: color 0.3s, background 0.3s;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/87815239/130119189-4f2176c8-2301-41b9-9e6a-c1077677cfcf.png)

Reverts part of code that caused this overflowing issue. 