### PR TITLE
chore(studio-be): rm calls to checkForDirtyModels as its already watched by nlu module

### DIFF
--- a/packages/studio-be/src/core/app/core-client.ts
+++ b/packages/studio-be/src/core/app/core-client.ts
@@ -27,9 +27,6 @@ export const coreActions = {
   setStudioReady: async () => {
     await coreClient?.post('/setStudioReady')
   },
-  checkForDirtyModels: async (botId: string) => {
-    await coreClient?.post('/checkForDirtyModels', { botId })
-  },
   syncBotLibs: async (botId: string) => {
     await coreClient?.post('/syncBotLibs', { botId, serverId: process.env.SERVER_ID })
   }

--- a/packages/studio-be/src/core/bots/bot-service.ts
+++ b/packages/studio-be/src/core/bots/bot-service.ts
@@ -26,7 +26,6 @@ export class BotService {
 
   private _botIds: string[] | undefined
   private static _mountedBots: Map<string, boolean> = new Map()
-  private _trainWatchers: { [botId: string]: ListenHandle } = {}
 
   constructor(
     @inject(TYPES.Logger)
@@ -254,16 +253,6 @@ export class BotService {
       BotService._mountedBots.set(botId, true)
       this._invalidateBotIds()
 
-      // Call the BP client to check if bots must be trained, until the logic is moved on the studio
-      this._trainWatchers[botId] = this.ghostService.forBot(botId).onFileChanged(async filePath => {
-        const hasPotentialNLUChange = filePath.includes('/intents/') || filePath.includes('/entities/')
-        if (!hasPotentialNLUChange) {
-          return
-        }
-
-        await coreActions.checkForDirtyModels(botId)
-      })
-
       return true
     } catch (err) {
       this.logger
@@ -289,7 +278,6 @@ export class BotService {
     BotService._mountedBots.set(botId, false)
 
     this._invalidateBotIds()
-    this._trainWatchers[botId]?.remove()
     debug.forBot(botId, `Unmount took ${Date.now() - startTime}ms`)
   }
 


### PR DESCRIPTION
Hey,

I might be wrong, but I believe there's no need for the studio to manually check for dirty models as nlu module already listen for such files:

If you check [this file](https://github.com/botpress/botpress/blob/master/modules/nlu/src/backend/application/scoped/definitions-service.ts#L61),

You'll see this code:
```ts
return this._definitionRepository.onFileChanged(async filePath => {
  const hasPotentialNLUChange = filePath.includes('/intents/') || filePath.includes('/entities/')
  if (!hasPotentialNLUChange) {
    return
  }
  await Promise.map(this._languages, this._notifyListeners)
})
```

which listens on ghost and notifies to web-socket.

Therefore I don't think studio should have to make a call to `POST /checkForDirtyModels`.

Am I missing something ? Tell me what you think!