### PR TITLE
fix(cms): display unregistered content-types instead of error message

### DIFF
--- a/packages/studio-be/src/common/typings.ts
+++ b/packages/studio-be/src/common/typings.ts
@@ -1,4 +1,4 @@
-import { BotDetails, Flow, FlowNode, IO, RolloutStrategy, StageRequestApprovers, StrategyUser } from 'botpress/sdk'
+import { ContentType, Flow, FlowNode, IO, RolloutStrategy, StageRequestApprovers, StrategyUser } from 'botpress/sdk'
 import { Request } from 'express'
 
 export interface IDisposeOnExit {
@@ -110,6 +110,23 @@ export interface LibraryElement {
   type: 'say_something' | 'execute'
   preview: string
   path: string
+}
+
+export interface ParsedContentType {
+  id: ContentType['id']
+  count: number
+  title: ContentType['title']
+  hidden: ContentType['hidden']
+  schema: {
+    json: ContentType['jsonSchema']
+    ui: ContentType['uiSchema']
+    title: ContentType['title']
+    renderer: ContentType['id']
+  }
+}
+export interface Categories {
+  enabled: ParsedContentType[]
+  disabled: Pick<ParsedContentType, 'id' | 'title'>[]
 }
 
 export interface OutgoingEventCommonArgs {

--- a/packages/studio-be/src/common/typings.ts
+++ b/packages/studio-be/src/common/typings.ts
@@ -125,8 +125,8 @@ export interface ParsedContentType {
   }
 }
 export interface Categories {
-  enabled: ParsedContentType[]
-  disabled: Pick<ParsedContentType, 'id' | 'title'>[]
+  registered: ParsedContentType[]
+  unregistered: Pick<ParsedContentType, 'id' | 'title'>[]
 }
 
 export interface OutgoingEventCommonArgs {

--- a/packages/studio-be/src/studio/cms/cms-router.ts
+++ b/packages/studio-be/src/studio/cms/cms-router.ts
@@ -23,8 +23,8 @@ export class CMSRouter extends CustomStudioRouter {
         const botId = req.params.botId
         const types = await this.cmsService.getAllContentTypes(botId)
         const categories: Categories = {
-          enabled: [],
-          disabled: types.disabled.map(x => ({
+          registered: [],
+          unregistered: types.disabled.map(x => ({
             id: x,
             title: x
           }))
@@ -34,7 +34,7 @@ export class CMSRouter extends CustomStudioRouter {
           const type = types.enabled[i]
           const count = await this.cmsService.countContentElementsForContentType(botId, type.id)
 
-          categories.enabled.push({
+          categories.registered.push({
             id: type.id,
             count,
             title: type.title,

--- a/packages/studio-be/src/studio/cms/cms-router.ts
+++ b/packages/studio-be/src/studio/cms/cms-router.ts
@@ -1,5 +1,5 @@
 import { ContentElement } from 'botpress/sdk'
-import { LibraryElement } from 'common/typings'
+import { Categories, LibraryElement, ParsedContentType } from 'common/typings'
 import { DefaultSearchParams } from 'core/cms'
 import _ from 'lodash'
 import { StudioServices } from 'studio/studio-router'
@@ -22,10 +22,19 @@ export class CMSRouter extends CustomStudioRouter {
       this.asyncMiddleware(async (req, res) => {
         const botId = req.params.botId
         const types = await this.cmsService.getAllContentTypes(botId)
+        const categories: Categories = {
+          enabled: [],
+          disabled: types.disabled.map(x => ({
+            id: x,
+            title: x
+          }))
+        }
 
-        const response = await Promise.map(types, async type => {
+        for (let i = 0; i < types.enabled.length; i++) {
+          const type = types.enabled[i]
           const count = await this.cmsService.countContentElementsForContentType(botId, type.id)
-          return {
+
+          categories.enabled.push({
             id: type.id,
             count,
             title: type.title,
@@ -36,10 +45,10 @@ export class CMSRouter extends CustomStudioRouter {
               title: type.title,
               renderer: type.id
             }
-          }
-        })
+          })
+        }
 
-        res.send(response)
+        res.send(categories)
       })
     )
 
@@ -146,7 +155,7 @@ export class CMSRouter extends CustomStudioRouter {
         const ids = await ghost.readFileAsObject<string[]>(CONTENT_FOLDER, LIBRARY_FILE)
 
         const elements = await this.cmsService.listContentElements(botId, undefined, { ids, from: 0, count: -1 }, lang)
-        const contentTypes = (await this.cmsService.getAllContentTypes(botId)).reduce((acc, curr) => {
+        const contentTypes = (await this.cmsService.getAllContentTypes(botId)).enabled.reduce((acc, curr) => {
           return { ...acc, [curr.id]: curr.title }
         }, {})
 

--- a/packages/studio-ui/package.json
+++ b/packages/studio-ui/package.json
@@ -111,6 +111,7 @@
     "@types/react-dom": "^16.8.6",
     "@types/react-jsonschema-form": "^1.7.5",
     "@types/react-router-dom": "^4.3.3",
+    "@types/redux-actions": "^2.2.1",
     "@types/slate": "0.47.1",
     "@types/slate-react": "0.22.5",
     "autoprefixer": "^6.5.3",

--- a/packages/studio-ui/src/web/components/Content/Select/index.tsx
+++ b/packages/studio-ui/src/web/components/Content/Select/index.tsx
@@ -384,7 +384,7 @@ class SelectContent extends Component<Props, State> {
 
 const mapStateToProps = (state: RootReducer) => ({
   contentItems: state.content.currentItems,
-  categories: state.content.categories.enabled
+  categories: state.content.categories.registered
 })
 
 const mapDispatchToProps = {

--- a/packages/studio-ui/src/web/components/Content/Select/index.tsx
+++ b/packages/studio-ui/src/web/components/Content/Select/index.tsx
@@ -1,12 +1,14 @@
 import axios from 'axios'
 import { Dialog, lang } from 'botpress/shared'
 import classnames from 'classnames'
+import { ParsedContentType } from 'common/typings'
 import React, { Component } from 'react'
 import { Alert, Button } from 'react-bootstrap'
 import Markdown from 'react-markdown'
 import { connect } from 'react-redux'
 import { deleteMedia, fetchContentCategories, fetchContentItems, upsertContentItem } from '~/actions'
 import Loading from '~/components/Util/Loading'
+import { RootReducer } from '~/reducers'
 import { CONTENT_TYPES_MEDIA } from '~/util/ContentDeletion'
 
 import withLanguage from '../../Util/withLanguage'
@@ -28,7 +30,7 @@ interface Props {
   deleteMedia: Function
   fetchContentItems: Function
   contentItems: any
-  categories: any
+  categories: ParsedContentType[]
   upsertContentItem: Function
   onSelect: any
   onClose: any
@@ -360,10 +362,7 @@ class SelectContent extends Component<Props, State> {
   }
 
   render() {
-    const {
-      state: { newItemCategory, show },
-      props: { container }
-    } = this
+    const { newItemCategory, show } = this.state
     const schema = (newItemCategory || {}).schema || { json: {}, ui: {} }
 
     return (
@@ -383,9 +382,9 @@ class SelectContent extends Component<Props, State> {
   }
 }
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state: RootReducer) => ({
   contentItems: state.content.currentItems,
-  categories: state.content.categories
+  categories: state.content.categories.enabled
 })
 
 const mapDispatchToProps = {

--- a/packages/studio-ui/src/web/components/Layout/CommandPalette.tsx
+++ b/packages/studio-ui/src/web/components/Layout/CommandPalette.tsx
@@ -97,7 +97,7 @@ const CommandPalette: FC<Props> = props => {
 const mapStateToProps = (state: RootReducer) => ({
   modules: state.modules,
   bots: state.bots.bots,
-  contentTypes: state.content.categories.enabled,
+  contentTypes: state.content.categories.registered,
   user: state.user
 })
 

--- a/packages/studio-ui/src/web/components/Layout/CommandPalette.tsx
+++ b/packages/studio-ui/src/web/components/Layout/CommandPalette.tsx
@@ -97,7 +97,7 @@ const CommandPalette: FC<Props> = props => {
 const mapStateToProps = (state: RootReducer) => ({
   modules: state.modules,
   bots: state.bots.bots,
-  contentTypes: state.content.categories,
+  contentTypes: state.content.categories.enabled,
   user: state.user
 })
 

--- a/packages/studio-ui/src/web/reducers/content.ts
+++ b/packages/studio-ui/src/web/reducers/content.ts
@@ -1,4 +1,4 @@
-import { LibraryElement } from 'common/typings'
+import { Categories, LibraryElement } from 'common/typings'
 import _ from 'lodash'
 import { handleActions } from 'redux-actions'
 import {
@@ -11,7 +11,7 @@ import {
   receiveQNAContentElement
 } from '~/actions'
 const defaultState = {
-  categories: null,
+  categories: { enabled: [], disabled: [] },
   currentItems: [],
   itemsById: {},
   itemsCount: 0
@@ -64,7 +64,7 @@ export default handleActions(
 )
 
 export interface ContentReducer {
-  categories: any
+  categories: Categories
   currentItems: any
   qnaUsage: any
   library: LibraryElement[]

--- a/packages/studio-ui/src/web/translations/en.json
+++ b/packages/studio-ui/src/web/translations/en.json
@@ -313,7 +313,8 @@
         "all": "All",
         "createNew": "Create new {name}",
         "createNewContent": "Create new content",
-        "filterByType": "Filter by Content Type"
+        "filterByType": "Filter by Content Type",
+        "unregisteredWarning": "Content-types is unregistered."
       },
       "switchToDefaultLang": "Switch to {defaultLang} and start editing",
       "usageModal": {

--- a/packages/studio-ui/src/web/translations/es.json
+++ b/packages/studio-ui/src/web/translations/es.json
@@ -287,7 +287,8 @@
         "all": "Todo",
         "createNew": "Crear nuevo {name}",
         "createNewContent": "Crear nuevo contenido",
-        "filterByType": "Filtrar por tipo de contenido"
+        "filterByType": "Filtrar por tipo de contenido",
+        "unregisteredWarning": "El tipo de contenido no está registrado."
       },
       "switchToDefaultLang": "Cambie a {defaultLang} y comience a editar",
       "usageModal": {

--- a/packages/studio-ui/src/web/translations/fr.json
+++ b/packages/studio-ui/src/web/translations/fr.json
@@ -309,7 +309,8 @@
       "sideBar": {
         "createNew": "Créer nouveau {name}",
         "createNewContent": "Créer nouveau contenu",
-        "filterByType": "Filtrer par type de contenu"
+        "filterByType": "Filtrer par type de contenu",
+        "unregisteredWarning": "Le type de contenu n'est pas enregistré."
       },
       "switchToDefaultLang": "Basculer sur {defaultLang} et commencer à modifier",
       "usageModal": {

--- a/packages/studio-ui/src/web/views/Content/SideBar.tsx
+++ b/packages/studio-ui/src/web/views/Content/SideBar.tsx
@@ -4,6 +4,7 @@ import { Categories } from 'common/typings'
 import _ from 'lodash'
 import React, { Component } from 'react'
 import { ItemList, SidePanel, SidePanelSection } from '~/components/Shared/Interface'
+import { SectionAction } from '~/components/Shared/Interface/typings'
 
 export default class SidebarView extends Component<Props> {
   CATEGORY_ALL = {
@@ -19,23 +20,23 @@ export default class SidebarView extends Component<Props> {
   }
 
   render() {
-    const contentTypeActions = this.props.categories.enabled.map(cat => {
+    const contentTypeActions: SectionAction[] = this.props.categories.enabled.map(cat => {
       return {
         id: `btn-create-${cat.id}`,
         label: lang.tr(cat.title),
-        onClick: () => {
+        onClick: (_: React.MouseEvent) => {
           this.props.handleCategorySelected(cat.id)
           this.props.handleAdd()
         }
       }
     })
 
-    const actions = [
+    const actions: SectionAction[] = [
       {
         tooltip: lang.tr('studio.content.sideBar.createNewContent'),
         id: 'btn-add-content',
         icon: 'add' as IconName,
-        items: [contentTypeActions]
+        items: contentTypeActions
       }
     ]
 
@@ -65,7 +66,13 @@ export default class SidebarView extends Component<Props> {
         label: lang.tr(cat.title),
         value: cat,
         selected: cat.id === this.CATEGORY_DISABLED.id,
-        actions: []
+        actions: [
+          cat.id !== this.CATEGORY_DISABLED.id && {
+            id: `btn-list-warning-${cat.id}`,
+            tooltip: 'Content-types is unregistered.',
+            icon: 'warning-sign' as IconName
+          }
+        ]
       }
     })
 

--- a/packages/studio-ui/src/web/views/Content/SideBar.tsx
+++ b/packages/studio-ui/src/web/views/Content/SideBar.tsx
@@ -20,7 +20,9 @@ export default class SidebarView extends Component<Props> {
   }
 
   render() {
-    const contentTypeActions: SectionAction[] = this.props.categories.enabled.map(cat => {
+    const { registered, unregistered } = this.props.categories
+
+    const contentTypeActions: SectionAction[] = registered.map(cat => {
       return {
         id: `btn-create-${cat.id}`,
         label: lang.tr(cat.title),
@@ -40,7 +42,7 @@ export default class SidebarView extends Component<Props> {
       }
     ]
 
-    const contentTypes = [this.CATEGORY_ALL, ...this.props.categories.enabled].map(cat => {
+    const contentTypes = [this.CATEGORY_ALL, ...registered].map(cat => {
       return {
         id: `btn-filter-${cat.id}`,
         label: !!cat.count ? `${lang.tr(cat.title)} (${cat.count})` : lang.tr(cat.title),
@@ -60,7 +62,7 @@ export default class SidebarView extends Component<Props> {
       }
     })
 
-    const contentTypesUnregistered = [this.CATEGORY_UNREGISTERED, ...this.props.categories.disabled].map(cat => {
+    const contentTypesUnregistered = [this.CATEGORY_UNREGISTERED, ...unregistered].map(cat => {
       return {
         id: `btn-filter-${cat.id}`,
         label: cat.title,
@@ -79,8 +81,10 @@ export default class SidebarView extends Component<Props> {
     return (
       <SidePanel>
         <SidePanelSection label={lang.tr('studio.content.sideBar.filterByType')} actions={actions}>
-          <ItemList items={contentTypes} onElementClicked={el => this.props.handleCategorySelected(el.value.id)} />
-          {this.props.categories.disabled.length > 0 && <ItemList items={contentTypesUnregistered} />}
+          {registered.length > 0 && (
+            <ItemList items={contentTypes} onElementClicked={el => this.props.handleCategorySelected(el.value.id)} />
+          )}
+          {unregistered.length > 0 && <ItemList items={contentTypesUnregistered} />}
         </SidePanelSection>
       </SidePanel>
     )

--- a/packages/studio-ui/src/web/views/Content/SideBar.tsx
+++ b/packages/studio-ui/src/web/views/Content/SideBar.tsx
@@ -33,14 +33,16 @@ export default class SidebarView extends Component<Props> {
       }
     })
 
-    const actions: SectionAction[] = [
-      {
-        tooltip: lang.tr('studio.content.sideBar.createNewContent'),
-        id: 'btn-add-content',
-        icon: 'add' as IconName,
-        items: contentTypeActions
-      }
-    ]
+    const actions: SectionAction[] = contentTypeActions.length
+      ? [
+          {
+            tooltip: lang.tr('studio.content.sideBar.createNewContent'),
+            id: 'btn-add-content',
+            icon: 'add' as IconName,
+            items: contentTypeActions
+          }
+        ]
+      : []
 
     const contentTypes = [this.CATEGORY_ALL, ...registered].map(cat => {
       return {

--- a/packages/studio-ui/src/web/views/Content/SideBar.tsx
+++ b/packages/studio-ui/src/web/views/Content/SideBar.tsx
@@ -80,7 +80,7 @@ export default class SidebarView extends Component<Props> {
       <SidePanel>
         <SidePanelSection label={lang.tr('studio.content.sideBar.filterByType')} actions={actions}>
           <ItemList items={contentTypes} onElementClicked={el => this.props.handleCategorySelected(el.value.id)} />
-          <ItemList items={contentTypesUnregistered} />
+          {this.props.categories.disabled.length > 0 && <ItemList items={contentTypesUnregistered} />}
         </SidePanelSection>
       </SidePanel>
     )

--- a/packages/studio-ui/src/web/views/Content/SideBar.tsx
+++ b/packages/studio-ui/src/web/views/Content/SideBar.tsx
@@ -13,9 +13,9 @@ export default class SidebarView extends Component<Props> {
     count: null
   }
 
-  CATEGORY_DISABLED = {
-    id: 'disabled',
-    title: lang.tr('disabled'),
+  CATEGORY_UNREGISTERED = {
+    id: 'unregistered',
+    title: lang.tr('unregistered'),
     count: null
   }
 
@@ -60,16 +60,16 @@ export default class SidebarView extends Component<Props> {
       }
     })
 
-    const contentTypesDisabled = [this.CATEGORY_DISABLED, ...this.props.categories.disabled].map(cat => {
+    const contentTypesUnregistered = [this.CATEGORY_UNREGISTERED, ...this.props.categories.disabled].map(cat => {
       return {
         id: `btn-filter-${cat.id}`,
-        label: lang.tr(cat.title),
+        label: cat.title,
         value: cat,
-        selected: cat.id === this.CATEGORY_DISABLED.id,
+        selected: cat.id === this.CATEGORY_UNREGISTERED.id,
         actions: [
-          cat.id !== this.CATEGORY_DISABLED.id && {
+          cat.id !== this.CATEGORY_UNREGISTERED.id && {
             id: `btn-list-warning-${cat.id}`,
-            tooltip: 'Content-types is unregistered.',
+            tooltip: lang.tr('studio.content.sideBar.unregisteredWarning'),
             icon: 'warning-sign' as IconName
           }
         ]
@@ -80,7 +80,7 @@ export default class SidebarView extends Component<Props> {
       <SidePanel>
         <SidePanelSection label={lang.tr('studio.content.sideBar.filterByType')} actions={actions}>
           <ItemList items={contentTypes} onElementClicked={el => this.props.handleCategorySelected(el.value.id)} />
-          <ItemList items={contentTypesDisabled} />
+          <ItemList items={contentTypesUnregistered} />
         </SidePanelSection>
       </SidePanel>
     )

--- a/packages/studio-ui/src/web/views/Content/SideBar.tsx
+++ b/packages/studio-ui/src/web/views/Content/SideBar.tsx
@@ -1,5 +1,6 @@
 import { IconName } from '@blueprintjs/core'
 import { lang } from 'botpress/shared'
+import { Categories } from 'common/typings'
 import _ from 'lodash'
 import React, { Component } from 'react'
 import { ItemList, SidePanel, SidePanelSection } from '~/components/Shared/Interface'
@@ -11,8 +12,14 @@ export default class SidebarView extends Component<Props> {
     count: null
   }
 
+  CATEGORY_DISABLED = {
+    id: 'disabled',
+    title: lang.tr('disabled'),
+    count: null
+  }
+
   render() {
-    const contentTypeActions = this.props.categories.map(cat => {
+    const contentTypeActions = this.props.categories.enabled.map(cat => {
       return {
         id: `btn-create-${cat.id}`,
         label: lang.tr(cat.title),
@@ -32,7 +39,7 @@ export default class SidebarView extends Component<Props> {
       }
     ]
 
-    const contentTypes = [this.CATEGORY_ALL, ...this.props.categories].map(cat => {
+    const contentTypes = [this.CATEGORY_ALL, ...this.props.categories.enabled].map(cat => {
       return {
         id: `btn-filter-${cat.id}`,
         label: !!cat.count ? `${lang.tr(cat.title)} (${cat.count})` : lang.tr(cat.title),
@@ -52,10 +59,21 @@ export default class SidebarView extends Component<Props> {
       }
     })
 
+    const contentTypesDisabled = [this.CATEGORY_DISABLED, ...this.props.categories.disabled].map(cat => {
+      return {
+        id: `btn-filter-${cat.id}`,
+        label: lang.tr(cat.title),
+        value: cat,
+        selected: cat.id === this.CATEGORY_DISABLED.id,
+        actions: []
+      }
+    })
+
     return (
       <SidePanel>
         <SidePanelSection label={lang.tr('studio.content.sideBar.filterByType')} actions={actions}>
           <ItemList items={contentTypes} onElementClicked={el => this.props.handleCategorySelected(el.value.id)} />
+          <ItemList items={contentTypesDisabled} />
         </SidePanelSection>
       </SidePanel>
     )
@@ -63,7 +81,7 @@ export default class SidebarView extends Component<Props> {
 }
 
 interface Props {
-  categories: any
+  categories: Categories
   handleCategorySelected: (id: string) => void
   selectedId: string
   readOnly: boolean

--- a/packages/studio-ui/src/web/views/Content/index.tsx
+++ b/packages/studio-ui/src/web/views/Content/index.tsx
@@ -1,4 +1,3 @@
-import { Callout, Intent } from '@blueprintjs/core'
 import { ActionBuilderProps, ContentElement } from 'botpress/sdk'
 import { lang, utils } from 'botpress/shared'
 import classnames from 'classnames'
@@ -212,7 +211,9 @@ class ContentView extends Component<Props, State> {
 
     const classNames = classnames(style.content, 'bp-content')
 
-    if (!categoriesRegistered.length && !categoriesUnregistered.length) {
+    const hasContentTypes = categoriesRegistered.length || categoriesUnregistered.length
+
+    if (!hasContentTypes) {
       return (
         <div className={classNames}>
           <Alert bsStyle="warning">
@@ -239,14 +240,14 @@ class ContentView extends Component<Props, State> {
           handleCategorySelected={this.handleCategorySelected}
         />
         <List
-          readOnly={!this.canEdit}
+          readOnly={!this.canEdit || !categoriesRegistered.length}
           count={
             this.state.selectedId === 'all'
               ? _.sumBy(categoriesRegistered, 'count') || 0
               : _.find(categoriesRegistered, { id: this.state.selectedId }).count
           }
           className={style.contentListWrapper}
-          contentItems={this.props.contentItems ?? []}
+          contentItems={categoriesRegistered.length ? this.props.contentItems ?? [] : []}
           handleRefresh={this.handleRefresh}
           handleEdit={this.handleModalShowForEdit}
           handleDeleteSelected={this.handleDeleteSelected}

--- a/packages/studio-ui/src/web/views/Content/index.tsx
+++ b/packages/studio-ui/src/web/views/Content/index.tsx
@@ -206,12 +206,13 @@ class ContentView extends Component<Props, State> {
 
   render() {
     const { selectedId = 'all', contentToEdit } = this.state
-    const categoriesEnabled = this.props.categories.enabled ?? []
-    const selectedCategory = _.find(categoriesEnabled, { id: this.currentContentType() })
+    const categoriesRegistered = this.props.categories.registered ?? []
+    const categoriesUnregistered = this.props.categories.unregistered ?? []
+    const selectedCategory = _.find(categoriesRegistered, { id: this.currentContentType() })
 
     const classNames = classnames(style.content, 'bp-content')
 
-    if (!categoriesEnabled.length) {
+    if (!categoriesRegistered.length && !categoriesUnregistered.length) {
       return (
         <div className={classNames}>
           <Alert bsStyle="warning">
@@ -241,8 +242,8 @@ class ContentView extends Component<Props, State> {
           readOnly={!this.canEdit}
           count={
             this.state.selectedId === 'all'
-              ? _.sumBy(categoriesEnabled, 'count') || 0
-              : _.find(categoriesEnabled, { id: this.state.selectedId }).count
+              ? _.sumBy(categoriesRegistered, 'count') || 0
+              : _.find(categoriesRegistered, { id: this.state.selectedId }).count
           }
           className={style.contentListWrapper}
           contentItems={this.props.contentItems ?? []}

--- a/packages/studio-ui/src/web/views/Content/index.tsx
+++ b/packages/studio-ui/src/web/views/Content/index.tsx
@@ -1,3 +1,4 @@
+import { Callout, Intent } from '@blueprintjs/core'
 import { ActionBuilderProps, ContentElement } from 'botpress/sdk'
 import { lang, utils } from 'botpress/shared'
 import classnames from 'classnames'

--- a/packages/studio-ui/src/web/views/Content/index.tsx
+++ b/packages/studio-ui/src/web/views/Content/index.tsx
@@ -204,7 +204,6 @@ class ContentView extends Component<Props, State> {
   }
 
   render() {
-    console.log('categories', this.props.categories)
     const { selectedId = 'all', contentToEdit } = this.state
     const categoriesEnabled = this.props.categories.enabled ?? []
     const selectedCategory = _.find(categoriesEnabled, { id: this.currentContentType() })

--- a/packages/studio-ui/src/web/views/Content/index.tsx
+++ b/packages/studio-ui/src/web/views/Content/index.tsx
@@ -1,7 +1,7 @@
 import { ActionBuilderProps, ContentElement } from 'botpress/sdk'
 import { lang, utils } from 'botpress/shared'
 import classnames from 'classnames'
-import { FlowView, NodeView } from 'common/typings'
+import { Categories, FlowView, NodeView } from 'common/typings'
 import _ from 'lodash'
 import React, { Component } from 'react'
 import { Alert } from 'react-bootstrap'
@@ -204,13 +204,14 @@ class ContentView extends Component<Props, State> {
   }
 
   render() {
+    console.log('categories', this.props.categories)
     const { selectedId = 'all', contentToEdit } = this.state
-    const categories = this.props.categories ?? []
-    const selectedCategory = _.find(categories, { id: this.currentContentType() })
+    const categoriesEnabled = this.props.categories.enabled ?? []
+    const selectedCategory = _.find(categoriesEnabled, { id: this.currentContentType() })
 
     const classNames = classnames(style.content, 'bp-content')
 
-    if (!categories.length) {
+    if (!categoriesEnabled.length) {
       return (
         <div className={classNames}>
           <Alert bsStyle="warning">
@@ -231,7 +232,7 @@ class ContentView extends Component<Props, State> {
       <Container>
         <Sidebar
           readOnly={!this.canEdit}
-          categories={categories}
+          categories={this.props.categories}
           selectedId={selectedId}
           handleAdd={this.handleCreateNew}
           handleCategorySelected={this.handleCategorySelected}
@@ -240,8 +241,8 @@ class ContentView extends Component<Props, State> {
           readOnly={!this.canEdit}
           count={
             this.state.selectedId === 'all'
-              ? _.sumBy(categories, 'count') || 0
-              : _.find(categories, { id: this.state.selectedId }).count
+              ? _.sumBy(categoriesEnabled, 'count') || 0
+              : _.find(categoriesEnabled, { id: this.state.selectedId }).count
           }
           className={style.contentListWrapper}
           contentItems={this.props.contentItems ?? []}
@@ -298,7 +299,7 @@ type Props = {
   upsertContentItem: Function
   deleteContentItems: Function
   deleteMedia: Function
-  categories: any
+  categories: Categories
   contentItems: ContentElementUsage[]
   flows: FlowReducer
   user: UserReducer

--- a/packages/studio-ui/src/web/views/FlowBuilder/diagram/nodes/SaySomethingContents/index.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/diagram/nodes/SaySomethingContents/index.tsx
@@ -74,7 +74,7 @@ const SayNodeContent: FC<Props> = props => {
 }
 
 const mapStateToProps = (state: RootReducer) => ({
-  categories: state.content.categories.enabled
+  categories: state.content.categories.registered
 })
 
 const mapDispatchToProps = {

--- a/packages/studio-ui/src/web/views/FlowBuilder/diagram/nodes/SaySomethingContents/index.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/diagram/nodes/SaySomethingContents/index.tsx
@@ -4,6 +4,7 @@ import React, { FC, useEffect } from 'react'
 import { connect } from 'react-redux'
 import { fetchContentCategories } from '~/actions'
 import withLanguage from '~/components/Util/withLanguage'
+import { RootReducer } from '~/reducers'
 import { getFormData } from '~/util/NodeFormData'
 import commonStyle from '~/views/FlowBuilder/common/style.scss'
 
@@ -72,8 +73,8 @@ const SayNodeContent: FC<Props> = props => {
   )
 }
 
-const mapStateToProps = state => ({
-  categories: state.content.categories
+const mapStateToProps = (state: RootReducer) => ({
+  categories: state.content.categories.enabled
 })
 
 const mapDispatchToProps = {

--- a/packages/studio-ui/src/web/views/FlowBuilder/sidePanelTopics/form/SaySomethingForm.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/sidePanelTopics/form/SaySomethingForm.tsx
@@ -198,7 +198,7 @@ const mapStateToProps = (state: RootReducer) => ({
   currentFlow: getCurrentFlow(state),
   currentFlowNode: getCurrentFlowNode(state) as any,
   user: state.user,
-  contentTypes: state.content.categories.enabled
+  contentTypes: state.content.categories.registered
 })
 
 const mapDispatchToProps = {

--- a/packages/studio-ui/src/web/views/FlowBuilder/sidePanelTopics/form/SaySomethingForm.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/sidePanelTopics/form/SaySomethingForm.tsx
@@ -198,7 +198,7 @@ const mapStateToProps = (state: RootReducer) => ({
   currentFlow: getCurrentFlow(state),
   currentFlowNode: getCurrentFlowNode(state) as any,
   user: state.user,
-  contentTypes: state.content.categories
+  contentTypes: state.content.categories.enabled
 })
 
 const mapDispatchToProps = {

--- a/packages/ui-shared/src/translations/en.json
+++ b/packages/ui-shared/src/translations/en.json
@@ -240,6 +240,7 @@
   "trigger": "Trigger",
   "type": "Type",
   "undo": "Undo",
+  "unregistered": "Unregistered",
   "update": "Update",
   "upload": "Upload",
   "usage": "Usage",

--- a/packages/ui-shared/src/translations/es.json
+++ b/packages/ui-shared/src/translations/es.json
@@ -240,6 +240,7 @@
   "trigger": "Disparador",
   "type": "Tipo",
   "undo": "Deshacer",
+  "unregistered": "No registrado",
   "update": "Actualizar",
   "upload": "Subir",
   "usage": "Uso",

--- a/packages/ui-shared/src/translations/fr.json
+++ b/packages/ui-shared/src/translations/fr.json
@@ -240,6 +240,7 @@
   "trigger": "Déclencheur",
   "type": "Type",
   "undo": "Annuler",
+  "unregistered": "Non enregistré",
   "update": "Actualiser",
   "upload": "Téléverser",
   "usage": "Utilisation",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1076,6 +1076,11 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
+"@types/redux-actions@^2.2.1":
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/@types/redux-actions/-/redux-actions-2.6.2.tgz#5956d9e7b9a644358e2c0610f47b1fa3060edc21"
+  integrity sha512-TvcINy8rWFANcpc3EiEQX9Yv3owM3d3KIrqr2ryUIOhYIYzXA/bhDZeGSSSuai62iVR2qMZUgz9tQ5kr0Kl+Tg==
+
 "@types/retry@*":
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.1.tgz#d8f1c0d0dc23afad6dc16a9e993a0865774b4065"
@@ -12686,7 +12691,7 @@ reduce-reducers@^0.4.3:
 
 redux-actions@^2.2.1:
   version "2.6.5"
-  resolved "https://registry.npmjs.org/redux-actions/-/redux-actions-2.6.5.tgz#bdca548768ee99832a63910c276def85e821a27e"
+  resolved "https://registry.yarnpkg.com/redux-actions/-/redux-actions-2.6.5.tgz#bdca548768ee99832a63910c276def85e821a27e"
   integrity sha512-pFhEcWFTYNk7DhQgxMGnbsB1H2glqhQJRQrtPb96kD3hWiZRzXHwwmFPswg6V2MjraXRXWNmuP9P84tvdLAJmw==
   dependencies:
     invariant "^2.2.4"


### PR DESCRIPTION
This PR adds support for editing content-elements event when at least one of the bot's content-types are unregistered. It also displays the list of unregistered content-types.

### Before

When you had an unregistered content-type, you would get this error on the CMS page:

![Screenshot from 2021-09-03 12-21-29](https://user-images.githubusercontent.com/9640576/132037745-7cbe4c61-0eae-4c27-a3e5-516b7c3d65cc.png)


### Now

![Screenshot from 2021-09-03 12-36-20](https://user-images.githubusercontent.com/9640576/132039478-5d1d25c7-5285-4275-8aac-96d5189c735c.png)

![Screenshot from 2021-09-03 12-36-35](https://user-images.githubusercontent.com/9640576/132039492-6e6e78a8-8089-440b-97ea-45ab7bb7fb54.png)

![Screenshot from 2021-09-03 13-25-46](https://user-images.githubusercontent.com/9640576/132044407-230de54a-8987-4783-9e45-17bfa6fbe802.png)




Closes DEV-1519