### PR TITLE
fix(core): fix redis pubsub by adding redis scopes

### DIFF
--- a/packages/studio-be/src/core/bpfs/redis-object-cache.ts
+++ b/packages/studio-be/src/core/bpfs/redis-object-cache.ts
@@ -1,15 +1,15 @@
 import { ObjectCache } from 'common/object-cache'
 import { IInitializeFromConfig } from 'common/typings'
 import { CacheInvalidators, MemoryObjectCache } from 'core/bpfs'
-import { getOrCreate as redisFactory } from 'core/distributed'
+import { makeRedisKey, getOrCreate as redisFactory } from 'core/distributed'
 import { TYPES } from 'core/types'
 import { EventEmitter } from 'events'
 import { inject, injectable } from 'inversify'
 import { Redis } from 'ioredis'
 
-const REDIS_INVALIDATE_STARTING_WITH = 'object-cache/invalidate-starting-with'
-const REDIS_INVALIDATE = 'object-cache/invalidate'
-const REDIS_SYNC = 'redis/sync'
+const REDIS_INVALIDATE_STARTING_WITH = makeRedisKey('object-cache/invalidate-starting-with')
+const REDIS_INVALIDATE = makeRedisKey('object-cache/invalidate')
+const REDIS_SYNC = makeRedisKey('redis/sync')
 
 @injectable()
 export class RedisObjectCache implements ObjectCache, IInitializeFromConfig {

--- a/packages/studio-be/src/core/distributed/async-redis.ts
+++ b/packages/studio-be/src/core/distributed/async-redis.ts
@@ -55,3 +55,7 @@ export const getOrCreate = (type: 'subscriber' | 'commands' | 'socket', url?: st
 
   return _clients[type]
 }
+
+export const makeRedisKey = (key: string): string => {
+  return process.env.BP_REDIS_SCOPE ? `${process.env.BP_REDIS_SCOPE}/${key}` : key
+}


### PR DESCRIPTION
This PR fixes an issue where using the studio with Redis enabled could cause synchronization issues since Botpress is using a `BP_REDIS_SCOPE` variable as a prefix for any Redis keys.