### PR TITLE
fix(studio): bot mig same behavior as core

### DIFF
--- a/packages/studio-be/src/core/migration/bot-migration-service.ts
+++ b/packages/studio-be/src/core/migration/bot-migration-service.ts
@@ -23,13 +23,9 @@ export class BotMigrationService {
   async executeMissingBotMigrations(botId: string, currentVersion: string, isDown?: boolean) {
     debug.forBot(botId, 'Checking missing migrations for bot ', { botId, currentVersion, isDown })
 
-    if (process.env.TESTMIG_ALL || process.env.TESTMIG_NEW) {
-      if (yn(process.env.TESTMIG_ALL)) {
-        currentVersion = '12.0.0'
-      } else {
-        const isBotOlder = semver.lt(currentVersion, process.BOTPRESS_VERSION)
-        currentVersion = isBotOlder ? currentVersion : process.BOTPRESS_VERSION
-      }
+    if (process.env.TESTMIG_NEW) {
+      const isBotOlder = semver.lt(currentVersion, process.BOTPRESS_VERSION)
+      currentVersion = isBotOlder ? currentVersion : process.BOTPRESS_VERSION
     }
 
     const missingMigrations = this.migService.filterMigrations(this.migService.getAllMigrations(), currentVersion, {

--- a/packages/studio-be/src/core/migration/bot-migration-service.ts
+++ b/packages/studio-be/src/core/migration/bot-migration-service.ts
@@ -4,6 +4,7 @@ import { GhostService } from 'core/bpfs'
 import { ConfigProvider } from 'core/config'
 import { PersistedConsoleLogger, centerText } from 'core/logger'
 import _ from 'lodash'
+import semver from 'semver'
 import stripAnsi from 'strip-ansi'
 import yn from 'yn'
 
@@ -23,7 +24,12 @@ export class BotMigrationService {
     debug.forBot(botId, 'Checking missing migrations for bot ', { botId, currentVersion, isDown })
 
     if (process.env.TESTMIG_ALL || process.env.TESTMIG_NEW) {
-      currentVersion = yn(process.env.TESTMIG_NEW) ? process.BOTPRESS_VERSION : '12.0.0'
+      if (yn(process.env.TESTMIG_ALL)) {
+        currentVersion = '12.0.0'
+      } else {
+        const isBotOlder = semver.lt(currentVersion, process.BOTPRESS_VERSION)
+        currentVersion = isBotOlder ? currentVersion : process.BOTPRESS_VERSION
+      }
     }
 
     const missingMigrations = this.migService.filterMigrations(this.migService.getAllMigrations(), currentVersion, {

--- a/packages/studio-be/src/core/migration/bot-migration-service.ts
+++ b/packages/studio-be/src/core/migration/bot-migration-service.ts
@@ -5,6 +5,7 @@ import { ConfigProvider } from 'core/config'
 import { PersistedConsoleLogger, centerText } from 'core/logger'
 import _ from 'lodash'
 import stripAnsi from 'strip-ansi'
+import yn from 'yn'
 
 import { MigrationEntry, MigrationFile, MigrationService, types } from '.'
 
@@ -20,6 +21,10 @@ export class BotMigrationService {
 
   async executeMissingBotMigrations(botId: string, currentVersion: string, isDown?: boolean) {
     debug.forBot(botId, 'Checking missing migrations for bot ', { botId, currentVersion, isDown })
+
+    if (process.env.TESTMIG_ALL || process.env.TESTMIG_NEW) {
+      currentVersion = yn(process.env.TESTMIG_NEW) ? process.BOTPRESS_VERSION : '12.0.0'
+    }
 
     const missingMigrations = this.migService.filterMigrations(this.migService.getAllMigrations(), currentVersion, {
       isDown,

--- a/packages/studio-be/src/migrations/v12_21_1-1618260400-bot_content_type_update.ts
+++ b/packages/studio-be/src/migrations/v12_21_1-1618260400-bot_content_type_update.ts
@@ -13,13 +13,13 @@ const migration: Migration = {
 
     const updateBotContentTypes = async (botId: string, botConfig: sdk.BotConfig) => {
       const newTypes = ['builtin_video', 'builtin_audio']
-      const { contentTypes } = botConfig.imports
+      const contentTypes = botConfig.imports.contentTypes || []
 
       // Fix for the previous migration which was removed
       const hasInvalidEntry = !!contentTypes.find(x => typeof x !== 'string')
       const hasMissingTypes = !newTypes.every(type => contentTypes.find(x => x === type))
 
-      if (hasInvalidEntry || hasMissingTypes) {
+      if (contentTypes.length && (hasInvalidEntry || hasMissingTypes)) {
         hasChanges = true
         botConfig.imports.contentTypes = _.uniq([...contentTypes.filter(x => typeof x === 'string'), ...newTypes])
 


### PR DESCRIPTION
Bot migrations were not taking into account TESTMIG_NEW or TESTMIG_ALL, so it was not in sync with the core. Simple fix, copied the logic from core.