### PR TITLE
fix(flow): fix clearing node action parameters on close

### DIFF
--- a/packages/studio-be/src/common/typings.ts
+++ b/packages/studio-be/src/common/typings.ts
@@ -173,7 +173,7 @@ export interface ActionParameterDefinition {
   description: string
   required: boolean
   type: string
-  default: any
+  default: string
 }
 
 export type ActionServerWithActions = ActionServer & {

--- a/packages/studio-ui/src/web/components/Content/Select/Widget.tsx
+++ b/packages/studio-ui/src/web/components/Content/Select/Widget.tsx
@@ -149,4 +149,4 @@ const ConnectedContentPicker = connect<DispatchProps, StateProps, OwnProps>(
 )(withLanguage(ContentPickerWidget))
 
 // Passing store explicitly since this component may be imported from another botpress-module
-export default props => <ConnectedContentPicker {...props} store={store} />
+export default (props: OwnProps) => <ConnectedContentPicker {...props} store={store} />

--- a/packages/studio-ui/src/web/views/FlowBuilder/nodeProps/ActionModalForm.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/nodeProps/ActionModalForm.tsx
@@ -1,6 +1,6 @@
 import { ContentElement } from 'botpress/sdk'
 import { confirmDialog, Dialog, lang } from 'botpress/shared'
-import { ActionParameterDefinition } from 'common/typings'
+import { ActionDefinition, ActionParameterDefinition, LocalActionDefinition } from 'common/typings'
 import _ from 'lodash'
 import React, { Component } from 'react'
 import { Button, OverlayTrigger, Radio, Tooltip } from 'react-bootstrap'
@@ -14,24 +14,18 @@ import ParametersTable, { Parameter } from './ParametersTable'
 import SelectActionDropdown from './SelectActionDropdown'
 import style from './style.scss'
 
-interface ActionMetadata {
-  params: ActionParameterDefinition[]
-  title: string
-  description: string
-  category: string
-}
 interface Action {
   label: string
   value: string
-  metadata: ActionMetadata
+  metadata: LocalActionDefinition
 }
-
 interface Item {
   type: string
   functionName?: string
   message?: string
   parameters: Parameter
 }
+
 interface OwnProps {
   show: boolean
   layoutv2?: boolean
@@ -47,7 +41,7 @@ type Props = StateProps & OwnProps
 interface State {
   actionType: string
   avActions: Action[]
-  actionMetadata?: ActionMetadata
+  actionMetadata?: LocalActionDefinition
   functionInputValue?: Action
   isEdit: boolean
   messageValue: string
@@ -108,7 +102,7 @@ class ActionModalForm extends Component<Props, State> {
         return {
           label: x.name,
           value: x.name,
-          metadata: { params: x.params, title: x.title, description: x.description, category: x.category }
+          metadata: { ...x }
         }
       })
     })

--- a/packages/studio-ui/src/web/views/FlowBuilder/nodeProps/ActionModalForm.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/nodeProps/ActionModalForm.tsx
@@ -1,6 +1,6 @@
 import { ContentElement } from 'botpress/sdk'
 import { confirmDialog, Dialog, lang } from 'botpress/shared'
-import { ActionDefinition, ActionParameterDefinition, LocalActionDefinition } from 'common/typings'
+import { ActionParameterDefinition, LocalActionDefinition } from 'common/typings'
 import _ from 'lodash'
 import React, { Component } from 'react'
 import { Button, OverlayTrigger, Radio, Tooltip } from 'react-bootstrap'

--- a/packages/studio-ui/src/web/views/FlowBuilder/nodeProps/ActionModalForm.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/nodeProps/ActionModalForm.tsx
@@ -1,4 +1,6 @@
+import { ContentElement } from 'botpress/sdk'
 import { confirmDialog, Dialog, lang } from 'botpress/shared'
+import { ActionParameterDefinition } from 'common/typings'
 import _ from 'lodash'
 import React, { Component } from 'react'
 import { Button, OverlayTrigger, Radio, Tooltip } from 'react-bootstrap'
@@ -8,15 +10,34 @@ import ContentPickerWidget from '~/components/Content/Select/Widget'
 import { LinkDocumentationProvider } from '~/components/Util/DocumentationProvider'
 import { RootReducer } from '~/reducers'
 
-import ParametersTable from './ParametersTable'
+import ParametersTable, { Parameter } from './ParametersTable'
 import SelectActionDropdown from './SelectActionDropdown'
 import style from './style.scss'
 
+interface ActionMetadata {
+  params: ActionParameterDefinition[]
+  title: string
+  description: string
+  category: string
+}
+interface Action {
+  label: string
+  value: string
+  metadata: ActionMetadata
+}
+
+interface Item {
+  type: string
+  functionName?: string
+  message?: string
+  parameters: Parameter
+}
 interface OwnProps {
   show: boolean
   layoutv2?: boolean
-  onSubmit: any
-  onClose: any
+  onSubmit: (item: Item) => void
+  onClose: () => void
+  item?: Item
 }
 
 type StateProps = ReturnType<typeof mapStateToProps>
@@ -25,32 +46,28 @@ type Props = StateProps & OwnProps
 
 interface State {
   actionType: string
-  avActions: any[]
-  actionMetadata: any
-  functionInputValue: any
+  avActions: Action[]
+  actionMetadata?: ActionMetadata
+  functionInputValue?: Action
   isEdit: boolean
   messageValue: string
-  functionParams: any
-  paramsDef: any
+  functionParams: Parameter
+  paramsDef: ActionParameterDefinition[]
 }
 
 class ActionModalForm extends Component<Props, State> {
-  private parametersTable: any
-
   state: State = {
     actionType: 'message',
     avActions: [],
-    actionMetadata: {},
-    functionInputValue: '',
     messageValue: '',
     functionParams: {},
     isEdit: false,
-    paramsDef: undefined
+    paramsDef: []
   }
 
-  textToItemId = text => _.get(text.match(/^say #!(.*)$/), '[1]')
+  textToItemId = (text: string) => _.get(text.match(/^say #!(.*)$/), '[1]')
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps: Props) {
     const { item } = nextProps
 
     if (this.props.show || !nextProps.show) {
@@ -79,7 +96,7 @@ class ActionModalForm extends Component<Props, State> {
     this.prepareActions()
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps: Props) {
     if (prevProps.actions !== this.props.actions) {
       this.prepareActions()
     }
@@ -97,15 +114,18 @@ class ActionModalForm extends Component<Props, State> {
     })
   }
 
-  onChangeType = type => () => {
+  onChangeType = (type: string) => () => {
     this.setState({ actionType: type })
   }
 
   resetForm() {
     this.setState({
       actionType: 'message',
-      functionInputValue: '',
-      messageValue: ''
+      functionInputValue: undefined,
+      messageValue: '',
+      functionParams: {},
+      paramsDef: [],
+      actionMetadata: undefined
     })
   }
 
@@ -113,8 +133,6 @@ class ActionModalForm extends Component<Props, State> {
     const { avActions } = this.state
 
     const tooltip = <Tooltip id="notSeeingAction">{lang.tr('studio.flow.node.actionsRegisteredOnServer')}</Tooltip>
-
-    const tooltip2 = <Tooltip id="whatIsThis">{lang.tr('studio.flow.node.youCanChangeActions')}</Tooltip>
 
     const help = (
       <OverlayTrigger placement="bottom" overlay={tooltip}>
@@ -124,17 +142,15 @@ class ActionModalForm extends Component<Props, State> {
 
     const paramsHelp = <LinkDocumentationProvider file="main/memory" />
 
-    const onParamsChange = params => {
-      params = _.values(params).reduce((sum, n) => {
+    const onArgsChange = (args: any) => {
+      args = _.values(args).reduce((sum, n) => {
         if (n.key === '') {
           return sum
         }
         return { ...sum, [n.key]: n.value }
       }, {})
-      this.setState({ functionParams: params })
+      this.setState({ functionParams: args })
     }
-
-    // const args = JSON.stringify(this.state.functionParams, null, 4)
 
     return (
       <div>
@@ -142,15 +158,15 @@ class ActionModalForm extends Component<Props, State> {
         <div className={style.section}>
           <SelectActionDropdown
             id="select-action"
-            value={this.state.functionInputValue}
+            value={this.state.functionInputValue || ''}
             options={avActions}
             onChange={val => {
               const fn = avActions.find(fn => fn.value === (val && val.value))
-              const paramsDefinition = _.get(fn, 'metadata.params') || []
+              const paramsDefinition = (_.get(fn, 'metadata.params') || []) as ActionParameterDefinition[]
               this.setState({
                 functionInputValue: val,
                 paramsDef: paramsDefinition,
-                actionMetadata: fn.metadata || {}
+                actionMetadata: fn.metadata || undefined
               })
 
               // TODO Detect if default or custom arguments
@@ -168,16 +184,15 @@ class ActionModalForm extends Component<Props, State> {
               })
             }}
           />
-          {this.state.actionMetadata.title && <h4>{this.state.actionMetadata.title}</h4>}
-          {this.state.actionMetadata.description && <Markdown source={this.state.actionMetadata.description} />}
+          {this.state.actionMetadata?.title && <h4>{this.state.actionMetadata.title}</h4>}
+          {this.state.actionMetadata?.description && <Markdown source={this.state.actionMetadata.description} />}
         </div>
         <h5>
           {lang.tr('studio.flow.node.actionParameters')} {paramsHelp}
         </h5>
         <div className={style.section}>
           <ParametersTable
-            ref={el => (this.parametersTable = el)}
-            onChange={onParamsChange}
+            onChange={onArgsChange}
             value={this.state.functionParams}
             definitions={this.state.paramsDef}
           />
@@ -187,7 +202,7 @@ class ActionModalForm extends Component<Props, State> {
   }
 
   renderSectionMessage() {
-    const handleChange = item => {
+    const handleChange = (item: ContentElement) => {
       this.setState({ messageValue: `say #!${item.id}` })
     }
 
@@ -212,13 +227,14 @@ class ActionModalForm extends Component<Props, State> {
     this.props.onSubmit &&
       this.props.onSubmit({
         type: this.state.actionType,
-        functionName: this.state.functionInputValue && this.state.functionInputValue.value,
+        functionName: this.state.functionInputValue?.value,
         message: this.state.messageValue,
         parameters: this.state.functionParams
       })
   }
 
   onClose = () => {
+    this.resetForm()
     this.props.onClose && this.props.onClose()
   }
 

--- a/packages/studio-ui/src/web/views/FlowBuilder/nodeProps/ParametersTable.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/nodeProps/ParametersTable.tsx
@@ -1,32 +1,48 @@
-import React, { Component } from 'react'
-import { OverlayTrigger, Tooltip } from 'react-bootstrap'
-
-import { Table } from 'react-bootstrap'
+import { lang } from 'botpress/shared'
 import classnames from 'classnames'
+import { ActionParameterDefinition } from 'common/typings'
 import _ from 'lodash'
+import React, { Component } from 'react'
+import { OverlayTrigger, Tooltip, Table } from 'react-bootstrap'
 
 import SmartInput from '~/components/SmartInput'
-import { lang } from 'botpress/shared'
 
-const style = require('./parameters.scss')
+import style from './parameters.scss'
 
-export default class ParametersTable extends Component {
-  constructor(props) {
+export interface Parameter {
+  [key: string]: string
+}
+
+export interface Arguments {
+  [key: string]: Parameter
+}
+
+interface Props {
+  value: Parameter
+  definitions: ActionParameterDefinition[]
+  className?: string
+  onChange: (args: Arguments) => void
+}
+
+interface State {
+  arguments: Arguments
+}
+
+export default class ParametersTable extends Component<Props, State> {
+  state: State
+
+  constructor(props: Props) {
     super(props)
     this.state = { arguments: this.transformArguments(props.value) }
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps: Props) {
     this.setState({ arguments: this.transformArguments(nextProps.value) })
   }
 
-  transformArguments(args) {
-    const valuesArray = [..._.map(args, (value, key) => ({ key, value })), { key: '', value: '' }]
+  transformArguments(params: Parameter): Arguments {
+    const valuesArray = [..._.map(params, (value, key) => ({ key, value })), { key: '', value: '' }]
     return _.fromPairs(valuesArray.map((el, i) => [i, el]))
-  }
-
-  getValues() {
-    return this.state.arguments
   }
 
   onChanged() {
@@ -36,7 +52,7 @@ export default class ParametersTable extends Component {
   }
 
   render() {
-    const renderRow = id => {
+    const renderRow = (id: string) => {
       const args = this.state.arguments
 
       const regenerateEmptyRowIfNeeded = () => {
@@ -62,7 +78,7 @@ export default class ParametersTable extends Component {
         }
       }
 
-      const editKey = evt => {
+      const editKey = (evt: React.ChangeEvent<HTMLInputElement>) => {
         if (evt.target.value !== '') {
           regenerateEmptyRowIfNeeded()
         } else {
@@ -78,7 +94,7 @@ export default class ParametersTable extends Component {
         this.onChanged()
       }
 
-      const editValue = value => {
+      const editValue = (value: string) => {
         if (value !== '') {
           regenerateEmptyRowIfNeeded()
         } else {
@@ -88,7 +104,7 @@ export default class ParametersTable extends Component {
         }
 
         this.setState({
-          arguments: { ...args, [id]: { value: value, key: args[id].key } }
+          arguments: { ...args, [id]: { value, key: args[id].key } }
         })
 
         this.onChanged()
@@ -99,13 +115,13 @@ export default class ParametersTable extends Component {
       const paramName = args[id].key
       const paramValue = args[id].value
 
-      const definition = _.find(this.props.definitions || [], { name: paramName }) || {
+      const definition = (_.find(this.props.definitions || [], { name: paramName }) || {
         required: false,
         description: lang.tr('studio.flow.node.noDescription'),
         default: '',
         type: 'Unknown',
         fake: true
-      }
+      }) as ActionParameterDefinition & { fake: boolean }
 
       const tooltip = (
         <Tooltip id={`param-${paramName}`}>


### PR DESCRIPTION
This PR fixes an issue where upon attempting to add multiple actions, the action parameters would not be reset

### Recording

#### Before

https://user-images.githubusercontent.com/9640576/132726343-d7f4a345-6b29-4019-977b-479571b86ba3.mp4

#### After

https://user-images.githubusercontent.com/9640576/132726351-11d329cf-57a2-44bf-a0e3-e9de42000d92.mp4

Closes #5213
Closes DEV-1401