### PR TITLE
feat(dev): binary branches

### DIFF
--- a/.github/workflows/branch_deleted.yml
+++ b/.github/workflows/branch_deleted.yml
@@ -1,0 +1,19 @@
+name: Branch deleted
+on: delete
+
+jobs:
+  remove:
+    if: github.event.ref_type == 'branch'
+    name: Remove Branch Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract Branch Name
+        id: extract_branch
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      - uses: dev-drprasad/delete-tag-and-release@v0.2.0
+        with:
+          delete_release: true
+          tag_name: pre-${{ steps.extract_branch.outputs.branch }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -17,15 +17,9 @@ jobs:
       - name: Get Release Details
         id: release_details
         uses: botpress/gh-actions/get_release_details@dev
-      - name: Fix changelog
+      - name: Fix Change Log
         id: changelog
         run: echo "::set-output name=value::${{ steps.release_details.outputs.changelog }}"
-      - name: Show info
-        run: |
-          echo ${{ steps.release_details.outputs.latest_tag }}
-          echo ${{ steps.release_details.outputs.is_new_release }}
-          echo ${{ steps.release_details.outputs.changelog }}
-          echo ${{ steps.changelog.outputs.value }}
       - name: Fetch Node Packages
         run: |
           yarn
@@ -34,8 +28,6 @@ jobs:
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
       - name: 'Build and Package'
-        env:
-          GITHUB_EVENT: ${{ toJson(github.event) }}
         run: |
           yarn build --prod
           yarn package

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,55 @@
+name: Pre-Release
+on:
+  push:
+    branches:
+      - '*'
+      - '!master'
+
+jobs:
+  pre_release_bin:
+    name: Pre-Release Binaries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+      - name: Git Unshallow
+        run: git fetch --prune --unshallow
+      - name: Get Release Details
+        id: release_details
+        uses: botpress/gh-actions/get_release_details@dev
+      - name: Fix changelog
+        id: changelog
+        run: echo "::set-output name=value::${{ steps.release_details.outputs.changelog }}"
+      - name: Show info
+        run: |
+          echo ${{ steps.release_details.outputs.latest_tag }}
+          echo ${{ steps.release_details.outputs.is_new_release }}
+          echo ${{ steps.release_details.outputs.changelog }}
+          echo ${{ steps.changelog.outputs.value }}
+      - name: Fetch Node Packages
+        run: |
+          yarn
+      - name: Extract Branch Name
+        id: extract_branch
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      - name: 'Build and Package'
+        env:
+          GITHUB_EVENT: ${{ toJson(github.event) }}
+        run: |
+          yarn build --prod
+          yarn package
+      - name: Rename Binary Files
+        uses: botpress/gh-actions/rename_binaries@master
+      - name: 'Release'
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ./bin/studio*
+          prerelease: true
+          draft: false
+          body: ${{ steps.changelog.outputs.value }}
+          name: ${{ steps.extract_branch.outputs.branch }}
+          tag_name: ${{ steps.extract_branch.outputs.branch }}
+          target_commitish: ${{ steps.extract_branch.outputs.branch }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -49,7 +49,7 @@ jobs:
           draft: false
           body: ${{ steps.changelog.outputs.value }}
           name: ${{ steps.extract_branch.outputs.branch }}
-          tag_name: ${{ steps.extract_branch.outputs.branch }}
+          tag_name: pre-${{ steps.extract_branch.outputs.branch }}
           target_commitish: ${{ steps.extract_branch.outputs.branch }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -16,7 +16,7 @@ jobs:
         run: git fetch --prune --unshallow
       - name: Get Release Details
         id: release_details
-        uses: botpress/gh-actions/get_release_details@dev
+        uses: botpress/gh-actions/get_release_details@master
       - name: Fix Change Log
         id: changelog
         run: echo "::set-output name=value::${{ steps.release_details.outputs.changelog }}"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   pre_release_bin:
-    name: Pre-Release Binaries
+    name: Build and Publish Binaries
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -39,7 +39,7 @@ jobs:
           files: ./bin/studio*
           prerelease: true
           draft: false
-          body: ${{ steps.changelog.outputs.value }}
+          body: ${{ steps.release_details.outputs.changelog }}
           name: ${{ steps.extract_branch.outputs.branch }}
           tag_name: pre-${{ steps.extract_branch.outputs.branch }}
           target_commitish: ${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,45 +15,26 @@ jobs:
       - name: Fetch Node Packages
         run: |
           yarn
-      - name: Get Previous Release Tag
-        id: previous_tag
-        uses: ./.github/workflows/code/latest_release_tag
-      - name: Get Current Version
-        id: extract_version
-        uses: Saionaro/extract-package-version@v1.0.6
-      - name: Validate Semver
-        id: validate_semver
-        run: |
-          valid_latest_tag=$(node ./node_modules/semver/bin/semver.js ${{ steps.previous_tag.outputs.tag }})
-          valid_current_version=$(node ./node_modules/semver/bin/semver.js ${{ steps.extract_version.outputs.version }})
-          change_log=$(node -e "require('./scripts/utils/changelog.js').build({ writeToFile: true }).then(cl => console.log(cl))")
-
-          # if not change log is truncated at first line
-          change_log="${change_log//'%'/'%25'}"
-          change_log="${change_log//$'\n'/'%0A'}"
-          change_log="${change_log//$'\r'/'%0D'}"
-
-          echo $valid_latest_tag
-          echo $valid_current_version
-          echo $change_log
-
-          echo "::set-output name=valid_latest_tag::$valid_latest_tag"
-          echo "::set-output name=valid_current_version::$valid_current_version"
-          echo "::set-output name=change_log::$change_log"
+      - name: Get Release Details
+        id: release_details
+        uses: botpress/gh-actions/get_release_details@dev
+      - name: Fix Change Log
+        id: changelog
+        run: echo "::set-output name=value::${{ steps.release_details.outputs.changelog }}"
       - name: 'Build and Package'
-        if: ${{ steps.validate_semver.outputs.valid_latest_tag != steps.validate_semver.outputs.valid_current_version }}
+        if: ${{ steps.release_details.outputs.is_new_release }}
         run: |
           yarn build --prod
           yarn package
       - name: 'Release'
-        if: ${{ steps.validate_semver.outputs.valid_latest_tag != steps.validate_semver.outputs.valid_current_version }}
+        if: ${{ steps.release_details.outputs.is_new_release }}
         uses: softprops/action-gh-release@v1
         with:
           files: ./bin/studio-v*
           prerelease: false
           draft: false
-          body: ${{ steps.validate_semver.outputs.change_log }}
-          name: v${{ steps.validate_semver.outputs.valid_current_version }}
-          tag_name: v${{ steps.validate_semver.outputs.valid_current_version }}
+          body: ${{ steps.changelog.outputs.value }}
+          name: v${{ steps.release_details.outputs.version }}
+          tag_name: v${{ steps.release_details.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           yarn
       - name: Get Release Details
         id: release_details
-        uses: botpress/gh-actions/get_release_details@dev
+        uses: botpress/gh-actions/get_release_details@master
       - name: Fix Change Log
         id: changelog
         run: echo "::set-output name=value::${{ steps.release_details.outputs.changelog }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@master
-      - name: Git Unshalow
+      - name: Git Unshallow
         run: git fetch --prune --unshallow
       - name: Fetch Node Packages
         run: |
           yarn
-      - name: Get Previous Tag
+      - name: Get Previous Release Tag
         id: previous_tag
-        uses: 'WyriHaximus/github-action-get-previous-tag@v1'
+        uses: ./.github/workflows/code/latest_release_tag
       - name: Get Current Version
         id: extract_version
         uses: Saionaro/extract-package-version@v1.0.6


### PR DESCRIPTION
Each time something is pushed on a branch, a binary is built and a "pre-release" is created with the binaries. Those binaries can be downloaded by the downloader on the main repo. 

Had to change the "latest tag" logic, because even if a tag is a pre-release, it was counted as an official tag
