### PR TITLE
fix(studio): add developer cue

### DIFF
--- a/.github/workflows/branch_deleted.yml
+++ b/.github/workflows/branch_deleted.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: dev-drprasad/delete-tag-and-release@v0.2.0
         with:
           delete_release: true
-          tag_name: pre-${{ steps.extract_branch.outputs.branch }}
+          tag_name: dev-${{ steps.extract_branch.outputs.branch }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -39,8 +39,9 @@ jobs:
       - name: Update Metadata File
         uses: botpress/gh-actions/merge_json@master
         with:
-          - path: packages/studio-be/out/metadata.json
-          - json: '{ "devBranch": "${{ steps.extract_branch.outputs.branch }}" }'
+          path: packages/studio-be/out/metadata.json
+          json: '{ "devBranch": "${{ steps.extract_branch.outputs.branch }}" }'
+
       - name: Rename Binary Files
         uses: botpress/gh-actions/rename_binaries@master
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -54,9 +54,9 @@ jobs:
           files: ./bin/studio*
           prerelease: true
           draft: false
-          body: ${{ steps.release_details.outputs.changelog }}
+          body: ${{ steps.changelog.outputs.value }}
           name: ${{ steps.extract_branch.outputs.branch }}
-          tag_name: pre-${{ steps.extract_branch.outputs.branch }}
+          tag_name: dev-${{ steps.extract_branch.outputs.branch }}
           target_commitish: ${{ steps.extract_branch.outputs.branch }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -12,28 +12,42 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@master
+
       - name: Git Unshallow
         run: git fetch --prune --unshallow
+
       - name: Get Release Details
         id: release_details
         uses: botpress/gh-actions/get_release_details@master
+
       - name: Fix Change Log
         id: changelog
         run: echo "::set-output name=value::${{ steps.release_details.outputs.changelog }}"
+
       - name: Fetch Node Packages
         run: |
           yarn
+
       - name: Extract Branch Name
         id: extract_branch
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-      - name: 'Build and Package'
-        run: |
-          yarn build --prod
-          yarn package
+
+      - name: Build Project
+        run: yarn build --prod
+
+      - name: Update Metadata File
+        uses: botpress/gh-actions/merge_json@master
+        with:
+          - path: packages/studio-be/out/metadata.json
+          - json: '{ "devBranch": "${{ steps.extract_branch.outputs.branch }}" }'
       - name: Rename Binary Files
         uses: botpress/gh-actions/rename_binaries@master
-      - name: 'Release'
+
+      - name: Package Binaries
+        run: yarn package
+
+      - name: Create Pre-Release
         uses: softprops/action-gh-release@v1
         with:
           files: ./bin/studio*

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -42,11 +42,11 @@ jobs:
           path: packages/studio-be/out/metadata.json
           json: '{ "devBranch": "${{ steps.extract_branch.outputs.branch }}" }'
 
-      - name: Rename Binary Files
-        uses: botpress/gh-actions/rename_binaries@master
-
       - name: Package Binaries
         run: yarn package
+
+      - name: Rename Binary Files
+        uses: botpress/gh-actions/rename_binaries@master
 
       - name: Create Pre-Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -53,8 +53,6 @@ jobs:
         with:
           files: ./bin/studio*
           prerelease: true
-          draft: false
-          body: ${{ steps.changelog.outputs.value }}
           name: ${{ steps.extract_branch.outputs.branch }}
           tag_name: dev-${{ steps.extract_branch.outputs.branch }}
           target_commitish: ${{ steps.extract_branch.outputs.branch }}

--- a/packages/studio-be/src/core/app/bootstrap.ts
+++ b/packages/studio-be/src/core/app/bootstrap.ts
@@ -89,14 +89,14 @@ async function resolveModules(moduleConfigs: ModuleConfigEntry[], resolver: Modu
   return { loadedModules, erroredModules }
 }
 
-const writeBanner = logger => {
-  const devBranch = process.DEV_BRANCH ? `Branch: ${process.DEV_BRANCH}` : ''
-  const isSource = process.pkg ? '' : 'Running from sources'
-  const infos = [`Version ${process.STUDIO_VERSION}`, devBranch, isSource]
+const showBanner = logger => {
+  const devBranch = process.DEV_BRANCH && `Branch: ${process.DEV_BRANCH}`
+  const fromSource = !process.pkg && 'Running from sources'
+  const infos = [`Version ${process.STUDIO_VERSION}`, devBranch, fromSource]
 
   logger.info(chalk`========================================
   {bold ${centerText('Botpress Studio', 40, 9)}}
-  ${chalk.blackBright(infos.filter(x => x.length).join(' - '))}
+  ${chalk.blackBright(infos.filter(x => x !== undefined).join(' - '))}
   ${_.repeat(' ', 9)}========================================`)
 }
 
@@ -118,7 +118,7 @@ async function start() {
     process.LOADED_MODULES[loadedModule.entryPoint.definition.name] = loadedModule.moduleLocation
   }
 
-  writeBanner(logger)
+  showBanner(logger)
 
   if (!fs.existsSync(process.APP_DATA_PATH)) {
     try {

--- a/packages/studio-be/src/core/app/bootstrap.ts
+++ b/packages/studio-be/src/core/app/bootstrap.ts
@@ -89,6 +89,17 @@ async function resolveModules(moduleConfigs: ModuleConfigEntry[], resolver: Modu
   return { loadedModules, erroredModules }
 }
 
+const writeBanner = logger => {
+  const devBranch = process.DEV_BRANCH ? `Branch: ${process.DEV_BRANCH}` : ''
+  const isSource = process.pkg ? '' : 'Running from sources'
+  const infos = [`Version ${process.STUDIO_VERSION}`, devBranch, isSource]
+
+  logger.info(chalk`========================================
+  {bold ${centerText('Botpress Studio', 40, 9)}}
+  ${chalk.blackBright(infos.filter(x => x.length).join(' - '))}
+  ${_.repeat(' ', 9)}========================================`)
+}
+
 async function start() {
   const app = createApp()
   await setupDebugLogger(app.logger)
@@ -107,10 +118,7 @@ async function start() {
     process.LOADED_MODULES[loadedModule.entryPoint.definition.name] = loadedModule.moduleLocation
   }
 
-  logger.info(chalk`========================================
-{bold ${centerText('Botpress Studio', 40, 9)}}
-{dim ${centerText(`Version ${process.STUDIO_VERSION}`, 40, 9)}}
-${_.repeat(' ', 9)}========================================`)
+  writeBanner(logger)
 
   if (!fs.existsSync(process.APP_DATA_PATH)) {
     try {

--- a/packages/studio-be/src/index.ts
+++ b/packages/studio-be/src/index.ts
@@ -87,6 +87,7 @@ try {
   process.CLUSTER_ENABLED = yn(process.env.CLUSTER_ENABLED) || false
   process.IS_PRO_ENABLED = yn(process.env.PRO_ENABLED) || yn(process.env['BP_CONFIG_PRO_ENABLED']) || false
   process.STUDIO_VERSION = metadata.version
+  process.DEV_BRANCH = metadata['devBranch']
   process.BOTPRESS_VERSION = process.env.BOTPRESS_VERSION!
 
   require('yargs')

--- a/packages/studio-be/src/typings/global.d.ts
+++ b/packages/studio-be/src/typings/global.d.ts
@@ -53,6 +53,8 @@ declare namespace NodeJS {
     IS_FAILSAFE: boolean
     DISABLE_CONTENT_SANDBOX: boolean
     USE_JWT_COOKIES: boolean
+
+    DEV_BRANCH?: string
   }
 }
 

--- a/packages/studio-be/src/typings/global.d.ts
+++ b/packages/studio-be/src/typings/global.d.ts
@@ -53,7 +53,7 @@ declare namespace NodeJS {
     IS_FAILSAFE: boolean
     DISABLE_CONTENT_SANDBOX: boolean
     USE_JWT_COOKIES: boolean
-
+    /** This property is set when the binary is built in a branch other than master */
     DEV_BRANCH?: string
   }
 }


### PR DESCRIPTION
I often lose time trying to find out why something doesn't work, to find out that I'm running a binary or that i'm not on the correct branch... So i'm adding some logic to help with the dx: 

- If the code is executed from source (versus a custom binary), it will add a small label telling so
- If it's a binary which has been built from a specific branch, the name will also be displayed

This doesn't affect the official binary, which will still display only the version like before.

![image](https://user-images.githubusercontent.com/42552874/132923451-830cb4f6-1405-428e-af39-4bbaf9f3ffc6.png)
