### PR TITLE
fix(flowbuilder): fix wait on issue with new rtl procedure

### DIFF
--- a/packages/studio-ui/src/web/components/SmartInput/index.tsx
+++ b/packages/studio-ui/src/web/components/SmartInput/index.tsx
@@ -142,7 +142,6 @@ class SmartInput extends React.Component<ConnectedProps, State> {
       plugins.push(createSingleLinePlugin())
     }
 
-    isRTLLocale(this.props.contentLang)
     return (
       <div
         className={cx(style.editor, this.props.className, {

--- a/packages/studio-ui/src/web/components/SmartInput/index.tsx
+++ b/packages/studio-ui/src/web/components/SmartInput/index.tsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux'
 import { refreshHints } from '~/actions'
 import store from '~/store'
 
+import { isRTLLocale } from '~/translations'
 import createMentionPlugin, { defaultSuggestionsFilter } from './Base'
 import style from './styles.scss'
 
@@ -27,7 +28,7 @@ interface ExposedProps {
 const { hasCommandModifier } = KeyBindingUtil
 const A_KEY = 65
 
-type ConnectedProps = ExposedProps & { hints: any[]; isRTLContentLang: boolean }
+type ConnectedProps = ExposedProps & { hints: any[]; contentLang: string }
 
 interface State {
   beforeContentStateText?: string
@@ -140,10 +141,12 @@ class SmartInput extends React.Component<ConnectedProps, State> {
     if (this.props.singleLine) {
       plugins.push(createSingleLinePlugin())
     }
+
+    isRTLLocale(this.props.contentLang)
     return (
       <div
         className={cx(style.editor, this.props.className, {
-          [style.rtl]: this.props.isRTLContentLang && !this.props.isCode
+          [style.rtl]: isRTLLocale(this.props.contentLang) && !this.props.isCode
         })}
         onClick={this.focus}
       >
@@ -175,7 +178,7 @@ class SmartInput extends React.Component<ConnectedProps, State> {
 }
 
 const mapDispatchToProps = { refreshHints }
-const mapStateToProps = ({ hints: { inputs }, language: { isRTLContentLang } }) => ({ hints: inputs, isRTLContentLang })
+const mapStateToProps = ({ hints: { inputs }, language: { contentLang } }) => ({ hints: inputs, contentLang })
 const ConnectedSmartInput = connect(mapStateToProps, mapDispatchToProps)(SmartInput)
 
 // Passing store explicitly since this component may be imported from another botpress-module

--- a/packages/studio-ui/src/web/components/SmartInput/styles.scss
+++ b/packages/studio-ui/src/web/components/SmartInput/styles.scss
@@ -50,8 +50,7 @@
     }
   }
 
-  &:hover,
-  &:focus-within {
+  &:hover, &:focus-within {
     .insertBtn {
       background: rgba(255, 255, 255, 0.9);
       span[icon] {
@@ -93,7 +92,7 @@
 
 .mentionSuggestions .description {
   font-size: 12px;
-  color: #5c7080;
+  color: #5C7080;
   line-height: 15px;
 }
 
@@ -105,7 +104,7 @@
 
   &:active,
   &.mentionSuggestionsEntryFocused {
-    background-color: #e5eaec;
+    background-color: #E5EAEC;
   }
 }
 

--- a/packages/studio-ui/src/web/translations/index.tsx
+++ b/packages/studio-ui/src/web/translations/index.tsx
@@ -33,21 +33,20 @@ const rtlLocales = [
   'yi' /* 'ייִדיש', Yiddish */
 ]
 
-// 'en-US' becomes ['en', '-us'] 'en' becomes ['en']
-const localeRegex = /^([a-zA-Z]*)([_\-a-zA-Z]*)$/
+const localeRegex = /^[a-z]{2,3}$/
 
 const isRTLLocale = (locale: string | undefined | null): boolean => {
   if (!locale) {
     return false
   }
-  locale = locale.toLowerCase()
-  const matches = localeRegex.exec(locale)
+
+  const matches = localeRegex.exec(locale.toLowerCase())
 
   if (!matches) {
     return false
   }
 
-  return rtlLocales.includes(matches[1])
+  return rtlLocales.includes(matches[0])
 }
 
 export { initializeTranslations, isRTLLocale }

--- a/packages/studio-ui/src/web/views/Config/index.tsx
+++ b/packages/studio-ui/src/web/views/Config/index.tsx
@@ -1,20 +1,18 @@
-import {Button, Callout, FileInput, FormGroup, InputGroup, Intent, TextArea} from '@blueprintjs/core'
+import { Button, Callout, FileInput, FormGroup, InputGroup, Intent, TextArea } from '@blueprintjs/core'
 import axios from 'axios'
-import {BotConfig} from 'botpress/sdk'
-import {confirmDialog, lang, toast} from 'botpress/shared'
-import {BotEditSchema} from 'common/validation'
+import { BotConfig } from 'botpress/sdk'
+import { confirmDialog, lang, toast } from 'botpress/shared'
+import { BotEditSchema } from 'common/validation'
 import Joi from 'joi'
 import _ from 'lodash'
-import React, {Component} from 'react'
-import {connect} from 'react-redux'
-import Select from 'react-select'
-import {fetchBotInformation} from '~/actions'
-import {Container, SidePanel, SidePanelSection} from '~/components/Shared/Interface'
-import {Item} from '~/components/Shared/Interface/typings'
-import {toastFailure, toastSuccess} from '~/components/Shared/Utils/Toaster'
+import React, { Component } from 'react'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
-
-import {ItemList} from '../../components/Shared/Interface'
+import { connect } from 'react-redux'
+import Select from 'react-select'
+import { fetchBotInformation } from '~/actions'
+import { Container, SidePanel, SidePanelSection, ItemList } from '~/components/Shared/Interface'
+import { Item } from '~/components/Shared/Interface/typings'
+import { toastFailure, toastSuccess } from '~/components/Shared/Utils/Toaster'
 
 import style from './style.scss'
 
@@ -170,7 +168,6 @@ class ConfigView extends Component<Props, State> {
     this.setState({ error: undefined, isSaving: true })
 
     const bot: Partial<BotConfig> = {
-      id: this.state.id,
       name: this.state.name,
       disabled: this.state.status.value === 'disabled',
       private: this.state.status.value === 'private',
@@ -336,18 +333,13 @@ class ConfigView extends Component<Props, State> {
             {this.state.activeTab === 'main' && (
               <div>
                 <h1 className={style.title}>{lang.tr('general')}</h1>
-                <FormGroup label={lang.tr('config.botId')} labelFor="botId">
-                  <div style={{ display: 'flex',  justifyContent: 'space-between' }}>
-                    <div style={{flexGrow: 1, marginRight: '10px'}}>
-                      <InputGroup id="bot-id" name="botId" value={this.state.id} readOnly />
+                <FormGroup label={lang.tr('config.botId')} labelFor="id">
+                  <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                    <div style={{ flexGrow: 1, marginRight: '10px' }}>
+                      <InputGroup id="id" name="id" value={this.state.id} readOnly />
                     </div>
-                    <CopyToClipboard
-                        text={this.state.id}
-                        onCopy={() => toast.info(lang.tr('config.copyToClipboard'))}
-                    >
-                      <Button
-                          icon="clipboard"
-                      />
+                    <CopyToClipboard text={this.state.id} onCopy={() => toast.info(lang.tr('config.copyToClipboard'))}>
+                      <Button icon="clipboard" />
                     </CopyToClipboard>
                   </div>
                 </FormGroup>

--- a/packages/studio-ui/src/web/views/FlowBuilder/common/action.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/common/action.tsx
@@ -6,11 +6,12 @@ import Markdown from 'react-markdown'
 import { connect } from 'react-redux'
 import { fetchContentItem, refreshFlowsLinks } from '~/actions'
 
-import { isMissingCurlyBraceClosure } from '../../../components/Util/form.util'
+import { isMissingCurlyBraceClosure } from '~/components/Util/form.util'
 import withLanguage from '../../../components/Util/withLanguage'
 import { ActionPopover } from './actionPopover'
 
 import style from './style.scss'
+import { isRTLLocale } from '~/translations'
 
 interface Props {
   text: string
@@ -20,7 +21,6 @@ interface Props {
   items: any
   contentLang: string
   layoutv2?: boolean
-  isRTLContentLang: boolean
 }
 
 export const textToItemId = text => text?.match(/^say #!(.*)$/)?.[1]
@@ -49,7 +49,6 @@ class ActionItem extends Component<Props> {
   }
 
   render() {
-    const { isRTLContentLang } = this.props
     const action = this.props.text
     const isAction = typeof action !== 'string' || !action.startsWith('say ')
 
@@ -128,7 +127,14 @@ class ActionItem extends Component<Props> {
     }
 
     return (
-      <div className={classnames(this.props.className, style['action-item'], style.msg, isRTLContentLang ? style.rtl : null)}>
+      <div
+        className={classnames(
+          this.props.className,
+          style['action-item'],
+          style.msg,
+          isRTLLocale(this.props.contentLang) ? style.rtl : null
+        )}
+      >
         <span className={style.icon}>💬</span>
         <span className={className} dangerouslySetInnerHTML={html} />
         {this.props.children}
@@ -137,10 +143,7 @@ class ActionItem extends Component<Props> {
   }
 }
 
-const mapStateToProps = state => ({
-  items: state.content.itemsById,
-  isRTLContentLang: state.language.isRTLContentLang
-})
+const mapStateToProps = state => ({ items: state.content.itemsById })
 const mapDispatchToProps = { fetchContentItem, refreshFlowsLinks }
 
 export default connect(mapStateToProps, mapDispatchToProps)(withLanguage(ActionItem))

--- a/packages/studio-ui/src/web/views/FlowBuilder/common/action.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/common/action.tsx
@@ -7,11 +7,11 @@ import { connect } from 'react-redux'
 import { fetchContentItem, refreshFlowsLinks } from '~/actions'
 
 import { isMissingCurlyBraceClosure } from '~/components/Util/form.util'
+import { isRTLLocale } from '~/translations'
 import withLanguage from '../../../components/Util/withLanguage'
 import { ActionPopover } from './actionPopover'
 
 import style from './style.scss'
-import { isRTLLocale } from '~/translations'
 
 interface Props {
   text: string
@@ -128,12 +128,9 @@ class ActionItem extends Component<Props> {
 
     return (
       <div
-        className={classnames(
-          this.props.className,
-          style['action-item'],
-          style.msg,
-          isRTLLocale(this.props.contentLang) ? style.rtl : null
-        )}
+        className={classnames(this.props.className, style['action-item'], style.msg, {
+          [style.rtl]: isRTLLocale(this.props.contentLang) ? style.rtl : null
+        })}
       >
         <span className={style.icon}>💬</span>
         <span className={className} dangerouslySetInnerHTML={html} />

--- a/packages/studio-ui/src/web/views/FlowBuilder/common/condition.jsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/common/condition.jsx
@@ -1,17 +1,12 @@
 import classnames from 'classnames'
 import _ from 'lodash'
 import Mustache from 'mustache'
-import React, {Component} from 'react'
-import {OverlayTrigger, Popover, Well} from 'react-bootstrap'
-import { connect } from 'react-redux'
+import React, { Component } from 'react'
+import { OverlayTrigger, Popover, Well } from 'react-bootstrap'
 
 const style = require('./style.scss')
 
-const mapStateToProps = (state) => ({
-  isRTLContentLang: state.language.isRTLContentLang
-})
-
-class ConditionItem extends Component {
+export default class ConditionItem extends Component {
   renderNormal(child) {
     return child
   }
@@ -33,6 +28,7 @@ class ConditionItem extends Component {
   render() {
     let raw
     const { position } = this.props
+
     const { condition, caption } = this.props.condition
 
     const renderer = caption ? this.renderOverlay : this.renderNormal
@@ -44,7 +40,7 @@ class ConditionItem extends Component {
       const restoreDots = str => str.replace(/--dot--/g, '.')
 
       const htmlTpl = caption.replace(/\[(.+)]/gi, x => {
-        const name = stripDots(x.replace(/\[|]/g, ''))
+        const name = stripDots(x.replace(/[\[\]]/g, ''))
         vars[name] = '<span class="val">' + _.escape(name) + '</span>'
         return '{{{' + name + '}}}'
       })
@@ -60,11 +56,9 @@ class ConditionItem extends Component {
 
     return renderer(
       <div className={classnames(this.props.className, style['action-item'], style['condition'])}>
-        <span className={style.name} dangerouslySetInnerHTML={{ __html: raw }}/>
+        <span className={style.name} dangerouslySetInnerHTML={{ __html: raw }} />
         {this.props.children}
       </div>
     )
   }
 }
-
-export default connect(mapStateToProps)(ConditionItem)

--- a/packages/studio-ui/src/web/views/FlowBuilder/diagram/nodes/BaseNodeModel.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/diagram/nodes/BaseNodeModel.tsx
@@ -38,7 +38,7 @@ export class BaseNodeModel extends NodeModel {
     const waitOnReceive = !_.isNil(onReceive)
 
     if (!this.ports['in'] && this.type !== 'trigger') {
-      // TODO: refactor thisfor Trigger
+      // TODO: refactor this for Trigger
       this.addPort(new StandardIncomingPortModel('in', inNodeType))
     }
 

--- a/packages/studio-ui/src/web/views/FlowBuilder/diagram/nodes/Components/NodeHeader.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/diagram/nodes/Components/NodeHeader.tsx
@@ -1,14 +1,17 @@
 import { Button } from '@blueprintjs/core'
 import cx from 'classnames'
 import React, { FC, SyntheticEvent, useState } from 'react'
+
 import { connect } from 'react-redux'
-import {RootReducer} from '~/reducers'
+import { RootReducer } from '~/reducers'
+import { isRTLLocale } from '~/translations'
 import { NodeDebugInfo } from '../../debugger'
 
 import { DebugInfo } from './DebugInfo'
 import style from './style.scss'
 
 type StateProps = ReturnType<typeof mapStateToProps>
+
 interface Props {
   setExpanded?: (expanded: boolean) => void
   expanded?: boolean
@@ -29,15 +32,17 @@ const NodeHeader: FC<StateProps & Props> = ({
   children,
   nodeType,
   className,
-  isRTLContentLang
+  contentLang
 }) => {
   const [startMouse, setStartMouse] = useState({ x: 0, y: 0 })
   const icon = expanded ? 'chevron-down' : 'chevron-right'
 
   return (
-    <div className={cx(style.headerWrapper, className, {
-      [style.rtl]: isRTLContentLang
-    })}>
+    <div
+      className={cx(style.headerWrapper, className, {
+        [style.rtl]: isRTLLocale(contentLang)
+      })}
+    >
       {debugInfo && <DebugInfo {...debugInfo} nodeType={nodeType} className={className}></DebugInfo>}
       <Button
         icon={setExpanded ? icon : null}
@@ -58,7 +63,7 @@ const NodeHeader: FC<StateProps & Props> = ({
 }
 
 const mapStateToProps = (state: RootReducer) => ({
-  isRTLContentLang: state.language.isRTLContentLang
+  contentLang: state.language.contentLang
 })
 
 export default connect(mapStateToProps)(NodeHeader)

--- a/packages/studio-ui/src/web/views/FlowBuilder/diagram/nodes/StandardContents/index.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/diagram/nodes/StandardContents/index.tsx
@@ -1,19 +1,22 @@
 import cx from 'classnames'
 import React, { FC } from 'react'
-import { connect } from 'react-redux'
-import { RootReducer } from '~/reducers'
+import store from '~/store'
+import { isRTLLocale } from '~/translations'
 import ConditionItem from '~/views/FlowBuilder/common/condition'
 import ActionItem from '../../../common/action'
 import { StandardPortWidget } from '../../nodes/Ports'
 import { BlockProps } from '../Block'
 import style from '../Components/style.scss'
+
 import localStyle from './style.scss'
 
-type StateProps = ReturnType<typeof mapStateToProps>
-type Props = StateProps & Pick<BlockProps, 'node'>
+type Props = Pick<BlockProps, 'node'>
 
-const StandardContents: FC<Props> = ({ node, isRTLContentLang }) => {
+const StandardContents: FC<Props> = ({ node }) => {
   const isWaiting = node.waitOnReceive
+  const {
+    language: { contentLang }
+  } = store.getState()
 
   return (
     <div className={cx(style.contentsWrapper, style.standard)}>
@@ -42,9 +45,12 @@ const StandardContents: FC<Props> = ({ node, isRTLContentLang }) => {
       {node.next?.map((item, i) => {
         const outputPortName = `out${i}`
         return (
-          <div key={`${i}.${item}`} className={cx(style.contentWrapper, style.small, {
-            [style.rtl]: isRTLContentLang
-          })}>
+          <div
+            key={`${i}.${item}`}
+            className={cx(style.contentWrapper, style.small, {
+              [style.rtl]: isRTLLocale(contentLang)
+            })}
+          >
             <div className={cx(style.content, style.readOnly)}>
               <ConditionItem condition={item} position={i} />
               <StandardPortWidget name={outputPortName} node={node} className={style.outRouting} />
@@ -55,9 +61,4 @@ const StandardContents: FC<Props> = ({ node, isRTLContentLang }) => {
     </div>
   )
 }
-
-const mapStateToProps = (state: RootReducer) => ({
-  isRTLContentLang: state.language.isRTLContentLang
-})
-
-export default connect(mapStateToProps)(StandardContents)
+export default StandardContents


### PR DESCRIPTION
This PR is about fixing known issues after merging [this PR](https://github.com/botpress/studio/pull/61)
The issue : The *WaitOn user input* is always displayed.
The solution: 
- I reverted the RTL updates 
- I also removed unnecessary props from the store
- I fetched the contentLang from the store on the Node component (cause of the issue) directly from the store object. 

(below how it looks like now)
![image](https://user-images.githubusercontent.com/13097764/133129316-dcd7f8d2-5633-4a93-ae6e-9da03568a049.png)
