### PR TITLE
fix(studio): retry set studio ready call

### DIFF
--- a/packages/studio-be/src/core/app/core-client.ts
+++ b/packages/studio-be/src/core/app/core-client.ts
@@ -25,7 +25,15 @@ export const coreActions = {
     await coreClient?.post('/invalidateCmsForBot', { botId })
   },
   setStudioReady: async () => {
-    await coreClient?.post('/setStudioReady')
+    const tryRequest = async () => {
+      try {
+        await coreClient?.post('/setStudioReady')
+      } catch {
+        setTimeout(tryRequest, 250)
+      }
+    }
+
+    await tryRequest()
   },
   checkForDirtyModels: async (botId: string) => {
     await coreClient?.post('/checkForDirtyModels', { botId })


### PR DESCRIPTION
I was able to reproduce the bug where the studio would be ready before the runtime server by placing a Promise.delay somewhere. This fix prevents the studio from crashing with a ECONNREFUSED error and just keeps retrying to inform the runtime that it is ready.

The fix works, but I'm not really sure why we start the studio before the runtime server is started. Maybe a better fix in the future would be to boot the runtime completely and then start the studio

Closes DEV-1470