### PR TITLE
fix(studio): error when state missing in debugger

### DIFF
--- a/packages/studio-ui/src/web/components/Layout/BottomPanel/Debugger/views/Summary.tsx
+++ b/packages/studio-ui/src/web/components/Layout/BottomPanel/Debugger/views/Summary.tsx
@@ -42,9 +42,9 @@ export default class Summary extends React.Component<Props> {
         <Dialog
           suggestions={this.props.event.suggestions}
           decision={this.props.event.decision}
-          stacktrace={this.props.event.state.__stacktrace}
+          stacktrace={this.props.event.state?.__stacktrace || []}
         />
-        <NLU session={this.props.event.state.session} nluData={this.props.event.nlu} />
+        <NLU session={this.props.event.state?.session || {}} nluData={this.props.event.nlu} />
 
         {this.props.event.ndu && (
           <Fragment>

--- a/packages/studio-ui/src/web/views/FlowBuilder/diagram/debugger.ts
+++ b/packages/studio-ui/src/web/views/FlowBuilder/diagram/debugger.ts
@@ -24,8 +24,6 @@ export const prepareEventForDiagram = (event: sdk.IO.IncomingEvent, flows: FlowV
     return { nodeInfos: [], highlightedNodes }
   }
 
-  const { context, __stacktrace } = event.state
-
   const getNode = (workflow: string, node: string): NodeDebugInfo => {
     workflow = workflow.replace('.flow.json', '')
 
@@ -40,8 +38,12 @@ export const prepareEventForDiagram = (event: sdk.IO.IncomingEvent, flows: FlowV
   }
 
   try {
-    highlightedNodes = processStackTrace(__stacktrace, context, getNode)
-    processErrors(event, getNode)
+    if (event.state) {
+      const { context, __stacktrace } = event.state
+
+      highlightedNodes = processStackTrace(__stacktrace, context, getNode)
+      processErrors(event, getNode)
+    }
   } catch (err) {
     console.error(`Error processing event: ${err}`)
   }


### PR DESCRIPTION
Fix when state is missing (eg: message sent when not authenticated).

![image](https://user-images.githubusercontent.com/42552874/134259897-9404e2ed-d3ec-483e-b282-27b1b959e274.png)
