### PR TITLE
fix(qna): fix language dropdown overlay issue 

### DIFF
--- a/packages/studio-ui/src/web/views/Qna/Components/QnA.tsx
+++ b/packages/studio-ui/src/web/views/Qna/Components/QnA.tsx
@@ -214,7 +214,7 @@ const QnA: FC<Props> = props => {
             </span>
           </div>
         </Button>
-        <MoreOptions show={showOption} onToggle={() => setShowOption(!showOption)} items={moreOptionsItems} />
+        <MoreOptions show={showOption} onToggle={() => setShowOption(!showOption)} items={moreOptionsItems} wrapInDiv />
       </div>
       {expanded && (
         <div key={contentLang} className={style.collapsibleWrapper}>

--- a/packages/studio-ui/src/web/views/Qna/style.scss
+++ b/packages/studio-ui/src/web/views/Qna/style.scss
@@ -250,13 +250,13 @@
   }
 
   .headerWrapper {
-    position: relative;
+    display: flex;
+    align-items: center;
 
     :global(.more-options-btn) {
       right: 0;
-      padding: 26px 31px 26px 26px;
-      top: 50%;
-      transform: translate(0, -50%);
+      margin-right: var(--spacing-x-large);
+      position: relative;
     }
 
     :global(.more-options-more-menu) {
@@ -267,9 +267,10 @@
   }
 
   .questionHeader {
+    flex-grow: 1;
     justify-content: flex-start;
-    padding: var(--spacing-x-large) 57px var(--spacing-x-large) var(--spacing-x-large) !important;
-    width: 100%;
+    padding: var(--spacing-x-large);
+    padding-right: var(--spacing-xxx-large);
 
     &:hover {
       background: #fff;
@@ -345,7 +346,6 @@
       display: flex;
       flex-grow: 0;
       flex-shrink: 1;
-      position: relative;
     }
   }
 

--- a/packages/ui-shared-lite/MoreOptions/MoreOptionsMenu.tsx
+++ b/packages/ui-shared-lite/MoreOptions/MoreOptionsMenu.tsx
@@ -1,0 +1,59 @@
+// @ts-nocheck
+import { Button, Icon, IconName } from '@blueprintjs/core'
+import cx from 'classnames'
+import React, { FC, Fragment } from 'react'
+import style from './style.scss'
+
+import { MoreOptionsMenuProps } from './typings'
+
+import style from './style.scss'
+
+const MoreOptionsMenu: FC<MoreOptionsMenuProps> = props => {
+  const { className, items } = props
+
+  const onAction = (e, action) => {
+    e.stopPropagation()
+    action()
+  }
+
+  return (
+    <ul className={cx(style.moreMenu, 'more-options-more-menu', className)}>
+      {items.map((item, index) => {
+        const { action, className, content, icon, label, type, selected } = item
+
+        return (
+          <li key={index} className={className}>
+            {content ? (
+              content
+            ) : (
+              <Fragment>
+                {action && (
+                  <Button
+                    icon={icon as IconName}
+                    minimal
+                    className={cx(style.moreMenuItem, {
+                      [style.delete]: type === 'delete',
+                      ['more-options-selected-option']: selected
+                    })}
+                    onClick={e => onAction(e, action)}
+                  >
+                    {label}
+                    {selected && <Icon icon="tick" iconSize={12} />}
+                  </Button>
+                )}
+                {!action && (
+                  <span className={cx(style.moreMenuItem, style.noHover, { [style.delete]: type === 'delete' })}>
+                    <Icon icon={icon as IconName} iconSize={16} />
+                    {label}
+                  </span>
+                )}
+              </Fragment>
+            )}
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+export default MoreOptionsMenu

--- a/packages/ui-shared-lite/MoreOptions/index.tsx
+++ b/packages/ui-shared-lite/MoreOptions/index.tsx
@@ -1,28 +1,22 @@
 // @ts-nocheck
-import { Button, Icon, IconName } from '@blueprintjs/core'
 import cx from 'classnames'
 import React, { FC, Fragment } from 'react'
 
 import Overlay from '../Overlay'
+import MoreOptionsMenu from './MoreOptionsMenu'
 
 import style from './style.scss'
 import { MoreOptionsProps } from './typings'
 
 const MoreOptions: FC<MoreOptionsProps> = props => {
-  const { show, onToggle, className, items, element } = props
+  const { show, onToggle, element } = props
 
   const handleToggle = e => {
     e.stopPropagation()
     onToggle(!show)
   }
 
-  const onAction = (e, action) => {
-    e.stopPropagation()
-    onToggle(false)
-    action()
-  }
-
-  return (
+  const el = (
     <Fragment>
       {!element && (
         <button
@@ -34,47 +28,12 @@ const MoreOptions: FC<MoreOptionsProps> = props => {
         </button>
       )}
       {element}
-      {show && (
-        <ul className={cx(style.moreMenu, 'more-options-more-menu', className)}>
-          {items.map((item, index) => {
-            const { action, className, content, icon, label, type, selected } = item
-
-            return (
-              <li key={index} className={className}>
-                {content ? (
-                  content
-                ) : (
-                  <Fragment>
-                    {action && (
-                      <Button
-                        icon={icon as IconName}
-                        minimal
-                        className={cx(style.moreMenuItem, {
-                          [style.delete]: type === 'delete',
-                          ['more-options-selected-option']: selected
-                        })}
-                        onClick={e => onAction(e, action)}
-                      >
-                        {label}
-                        {selected && <Icon icon="tick" iconSize={12} />}
-                      </Button>
-                    )}
-                    {!action && (
-                      <span className={cx(style.moreMenuItem, style.noHover, { [style.delete]: type === 'delete' })}>
-                        <Icon icon={icon as IconName} iconSize={16} />
-                        {label}
-                      </span>
-                    )}
-                  </Fragment>
-                )}
-              </li>
-            )
-          })}
-        </ul>
-      )}
+      {show && <MoreOptionsMenu {...props} />}
       {show && <Overlay onClick={handleToggle} />}
     </Fragment>
   )
+
+  return props.wrapInDiv ? <div className={style.moreOptionsWrapper}>{el}</div> : el
 }
 
 export default MoreOptions

--- a/packages/ui-shared-lite/MoreOptions/style.scss
+++ b/packages/ui-shared-lite/MoreOptions/style.scss
@@ -1,3 +1,7 @@
+.moreOptionsWrapper {
+  position: relative;
+}
+
 .moreBtn {
   background: none;
   padding: 0;

--- a/packages/ui-shared-lite/MoreOptions/style.scss.d.ts
+++ b/packages/ui-shared-lite/MoreOptions/style.scss.d.ts
@@ -7,6 +7,7 @@ interface CssExports {
   'moreBtnDots': string;
   'moreMenu': string;
   'moreMenuItem': string;
+  'moreOptionsWrapper': string;
   'noHover': string;
 }
 declare var cssExports: CssExports;

--- a/packages/ui-shared-lite/MoreOptions/typings.d.ts
+++ b/packages/ui-shared-lite/MoreOptions/typings.d.ts
@@ -1,13 +1,18 @@
 // @ts-nocheck
 import { IconName } from '@blueprintjs/icons'
 
-export interface MoreOptionsProps {
+export interface MoreOptionsProps extends MoreOptionsMenuProps {
   show: boolean
   onToggle: (value: boolean) => void
   children?: any
-  className?: string
   element?: JSX.Element
+  wrapInDiv?:boolean
+}
+
+export interface MoreOptionsMenuProps {
   items: MoreOptionsItems[]
+  onToggle: (value: boolean) => void
+  className?: string
 }
 
 export interface MoreOptionsItems {


### PR DESCRIPTION
The issue is easily reproductible. I thought it was a z-index thing but turns out z-index don't apply to `position:relative` elements. Removing that position relative statement had me play around with a bunch of styles. In the end, there is no visible change except the actual fix (see screencaps)

Before  :
<img width="329" alt="Screen Shot 2021-09-23 at 11 48 16 AM" src="https://user-images.githubusercontent.com/955524/134541757-387cc902-28d1-4047-994f-8f7892f5fbe3.png">
 
After:
<img width="486" alt="Screen Shot 2021-09-23 at 11 46 59 AM" src="https://user-images.githubusercontent.com/955524/134541798-2682aca5-b68c-4c35-a917-12843efaff34.png">

Closes https://github.com/botpress/botpress/issues/5417 DEV-1693