### PR TITLE
fix(studio): prevent creating empty actions

### DIFF
--- a/packages/studio-ui/src/web/views/FlowBuilder/nodeProps/ActionModalForm.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/nodeProps/ActionModalForm.tsx
@@ -20,7 +20,7 @@ interface Action {
   metadata: LocalActionDefinition
 }
 interface Item {
-  type: string
+  type: ActionType
   functionName?: string
   message?: string
   parameters: Parameter
@@ -35,11 +35,12 @@ interface OwnProps {
 }
 
 type StateProps = ReturnType<typeof mapStateToProps>
-
 type Props = StateProps & OwnProps
 
+type ActionType = 'code' | 'message'
+
 interface State {
-  actionType: string
+  actionType: ActionType
   avActions: Action[]
   actionMetadata?: LocalActionDefinition
   functionInputValue?: Action
@@ -108,7 +109,7 @@ class ActionModalForm extends Component<Props, State> {
     })
   }
 
-  onChangeType = (type: string) => () => {
+  onChangeType = (type: ActionType) => () => {
     this.setState({ actionType: type })
   }
 
@@ -218,18 +219,28 @@ class ActionModalForm extends Component<Props, State> {
 
   onSubmit = () => {
     this.resetForm()
-    this.props.onSubmit &&
-      this.props.onSubmit({
-        type: this.state.actionType,
-        functionName: this.state.functionInputValue?.value,
-        message: this.state.messageValue,
-        parameters: this.state.functionParams
-      })
+    this.props.onSubmit?.({
+      type: this.state.actionType,
+      functionName: this.state.functionInputValue?.value,
+      message: this.state.messageValue,
+      parameters: this.state.functionParams
+    })
   }
 
   onClose = () => {
     this.resetForm()
-    this.props.onClose && this.props.onClose()
+    this.props.onClose?.()
+  }
+
+  isValid = () => {
+    switch (this.state.actionType) {
+      case 'code':
+        return this.state.functionInputValue?.value.length
+      case 'message':
+        return this.state.messageValue.length
+      default:
+        return false
+    }
   }
 
   render() {
@@ -263,7 +274,7 @@ class ActionModalForm extends Component<Props, State> {
           <Button id="btn-cancel-action" onClick={this.onClose}>
             {lang.tr('cancel')}
           </Button>
-          <Button id="btn-submit-action" type="submit" bsStyle="primary">
+          <Button id="btn-submit-action" type="submit" bsStyle="primary" disabled={!this.isValid()}>
             {this.state.isEdit
               ? lang.tr('studio.flow.node.finishUpdateAction')
               : lang.tr('studio.flow.node.finishAddAction')}{' '}


### PR DESCRIPTION
This PR fixes an issue where it was possible to add empty actions to a node. To fix this issue, a validation was added to make sure the form is valid before enabling the submit button.

**Before**

https://user-images.githubusercontent.com/9640576/134557976-7e5ce35f-d8a4-416d-8d86-5a126bbf86d6.mp4

**After**

https://user-images.githubusercontent.com/9640576/134557986-284807fd-f5d8-41d4-a882-4cf1e196edaf.mp4

Closes #76 and DEV-1638