### PR TITLE
fix(studio): fix permissions for libraries

### DIFF
--- a/packages/studio-be/src/studio/libraries/libraries-router.ts
+++ b/packages/studio-be/src/studio/libraries/libraries-router.ts
@@ -17,6 +17,7 @@ export class LibrariesRouter extends CustomStudioRouter {
     const router = this.router
     router.get(
       '/list',
+      this.needPermissions('read', 'module.code-editor'),
       this.asyncMiddleware(async (req: any, res: any) => {
         if (!(await this.libService.isInitialized(req.params.botId))) {
           return []
@@ -30,6 +31,7 @@ export class LibrariesRouter extends CustomStudioRouter {
 
     router.post(
       '/executeNpm',
+      this.needPermissions('read', 'module.code-editor'),
       this.asyncMiddleware(async (req: any, res: any) => {
         const { botId } = req.params
         const { command } = req.body
@@ -64,6 +66,7 @@ export class LibrariesRouter extends CustomStudioRouter {
 
     router.post(
       '/sync',
+      this.needPermissions('read', 'module.code-editor'),
       this.asyncMiddleware(async (req: any, res: any) => {
         const { botId } = req.params
 
@@ -77,6 +80,7 @@ export class LibrariesRouter extends CustomStudioRouter {
 
     router.post(
       '/add',
+      this.needPermissions('read', 'module.code-editor'),
       this.asyncMiddleware(async (req: any, res: any) => {
         const { botId } = req.params
         const { name, version } = validateNameVersion(req.body)
@@ -96,6 +100,7 @@ export class LibrariesRouter extends CustomStudioRouter {
 
     router.post(
       '/delete',
+      this.needPermissions('read', 'module.code-editor'),
       this.asyncMiddleware(async (req, res) => {
         const { botId } = req.params
         const { name } = validateNameVersion(req.body)

--- a/packages/studio-ui/src/web/components/Layout/Sidebar.tsx
+++ b/packages/studio-ui/src/web/components/Layout/Sidebar.tsx
@@ -48,7 +48,7 @@ const BASIC_MENU_ITEMS = [
     id: 'libraries',
     name: lang.tr('libraries.fullName'),
     path: '/libraries',
-    rule: { res: 'bot.nlu', op: 'read' },
+    rule: { res: 'module.code-editor', op: 'read' },
     icon: 'book'
   }
 ]


### PR DESCRIPTION
Users with bot.nlu permissions were able to play around with libraries... moved the perms with the code editor
![image](https://user-images.githubusercontent.com/42552874/134558785-e4584e99-9493-4636-a65d-1b30ed97c501.png)
