### PR TITLE
fix(studio): allow changing content-type when editing node content-element

### DIFF
--- a/packages/studio-be/src/sdk/botpress.d.ts
+++ b/packages/studio-be/src/sdk/botpress.d.ts
@@ -1028,6 +1028,7 @@ declare module 'botpress/sdk' {
     createdOn: Date
     modifiedOn: Date
     createdBy: string
+    botId?: string
   }
 
   /**

--- a/packages/studio-ui/src/web/actions/index.ts
+++ b/packages/studio-ui/src/web/actions/index.ts
@@ -242,7 +242,12 @@ export const fetchContentCategories = () => dispatch =>
   })
 
 export const receiveContentItems = createAction('CONTENT/ITEMS/RECEIVE')
-export const fetchContentItems = ({ contentType, ...query }) => dispatch => {
+export const fetchContentItems = ({
+  contentType,
+  ...query
+}: {
+  contentType: string
+} & sdk.SearchParams) => dispatch => {
   const type = contentType && contentType !== 'all' ? `${contentType}/` : ''
 
   return axios
@@ -284,11 +289,15 @@ export const fetchContentItemsCount = (contentType = 'all') => dispatch =>
     .get(`${window.STUDIO_API_PATH}/cms/elements/count`, { params: { contentType } })
     .then(data => dispatch(receiveContentItemsCount(data)))
 
-export const upsertContentItem = ({ contentType, formData, modifyId }) => () =>
+export const upsertContentItem = ({
+  contentType,
+  formData,
+  modifyId
+}: Pick<sdk.ContentElement, 'contentType' | 'formData'> & { modifyId: string }) => () =>
   axios.post(`${window.STUDIO_API_PATH}/cms/${contentType}/element/${modifyId || ''}`, { formData })
 
 export const deleteContentItems = data => () => axios.post(`${window.STUDIO_API_PATH}/cms/elements/bulk_delete`, data)
-export const deleteMedia = data => () => axios.post(`${window.STUDIO_API_PATH}/media/delete`, data)
+export const deleteMedia = (data: sdk.FormData) => () => axios.post(`${window.STUDIO_API_PATH}/media/delete`, data)
 
 // UI
 export const viewModeChanged = createAction('UI/VIEW_MODE_CHANGED')


### PR DESCRIPTION
This PR fixes an issue where when editing a selected content-element in a node, it would not let you change the content-type. The option was only provided when adding a content-element.

**Before**

https://user-images.githubusercontent.com/9640576/134696550-3cf39f59-4c03-48ec-96a6-930489a98284.mp4

**After**

https://user-images.githubusercontent.com/9640576/134696270-1c18a5a0-c774-4da2-946f-05ba9893ddfc.mp4

Closes https://github.com/botpress/botpress/issues/5334
Also closes DEV-1535