### PR TITLE
chore(dx): added a default env file used in launch.json file for debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ metadata.json
 *.node.bak
 .idea/
 .idea
+.env.debug

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "pwa-node",
+      "request": "launch",
+      "name": "Launch Studio BE",
+      "skipFiles": ["<node_internals>/**"],
+      "program": "${workspaceFolder}/packages/studio-be/out/index.js",
+      "outFiles": ["${workspaceFolder}/packages/studio-be/out/**/*.js"],
+      "sourceMaps": true,
+      "console": "integratedTerminal",
+      "envFile": "${workspaceFolder}/.env.debug"
+    }
+  ]
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,4 +15,4 @@ gulp.task('build:studio-ui', gulp.series([studio.buildUi, studio.clean, studio.c
 
 gulp.task('build', gulp.series([studio.buildNativeExtensions, 'build:studio-be', 'build:shared', 'build:studio-ui']))
 
-gulp.task('create:env.debug', gulp.series([envDebug.createEmptyEnvFileForDebugging]))
+gulp.task('create:env.debug', gulp.series([envDebug.createDefaultEnvFileForDebugging]))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,6 +2,7 @@ const gulp = require('gulp')
 
 const shared = require('./scripts/gulp.shared')
 const studio = require('./scripts/gulp.studio')
+const envDebug = require('./scripts/gulp.env.debug')
 
 gulp.task('build:shared', gulp.series([shared.clean, shared.buildLite, shared.build]))
 
@@ -13,3 +14,5 @@ gulp.task('build:studio-be', gulp.series([studio.writeMetadata, studio.buildBack
 gulp.task('build:studio-ui', gulp.series([studio.buildUi, studio.clean, studio.cleanAssets, studio.copy]))
 
 gulp.task('build', gulp.series([studio.buildNativeExtensions, 'build:studio-be', 'build:shared', 'build:studio-ui']))
+
+gulp.task('create:env.debug', gulp.series([envDebug.createEmptyEnvFileForDebugging]))

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "outputPath": "./bin"
   },
   "scripts": {
+    "postinstall": "yarn cmd create:env.debug --location ./.env.debug",
     "cmd": "yarn run gulp",
     "build": "yarn cmd build",
     "package": "yarn cmd package:studio",
@@ -54,6 +55,7 @@
     "gulp-cli": "^2.3.0",
     "gulp-file": "^0.4.0",
     "gulp-rimraf": "^1.0.0",
+    "minimist": "^1.2.5",
     "pkg": "^4.3.7",
     "prettier": "^1.19.1",
     "semver": "^7.3.5",

--- a/scripts/gulp.env.debug.js
+++ b/scripts/gulp.env.debug.js
@@ -16,13 +16,11 @@ ROOT_PATH=''
 INTERNAL_PASSWORD=${DEFAULT_INTERNAL_PASSWORD}
 `
 
-const createEmptyEnvFileForDebugging = cb => {
+const createDefaultEnvFileForDebugging = cb => {
   const { location } = minimist(process.argv.slice(2))
   if (!location) {
     return cb(
-      new Error(
-        'Creating empty env file for debugging requires the desired file location as 1st positional parameter.'
-      )
+      new Error('Creating empty env file for debugging requires the desired file location as 1st positional parameter.')
     )
   }
 
@@ -35,5 +33,5 @@ const createEmptyEnvFileForDebugging = cb => {
 }
 
 module.exports = {
-  createEmptyEnvFileForDebugging
+  createDefaultEnvFileForDebugging
 }

--- a/scripts/gulp.env.debug.js
+++ b/scripts/gulp.env.debug.js
@@ -21,7 +21,7 @@ const createEmptyEnvFileForDebugging = cb => {
   if (!location) {
     return cb(
       new Error(
-        'Creating empty env file for debugging requires a the desired file location as 1st positional parameter.'
+        'Creating empty env file for debugging requires the desired file location as 1st positional parameter.'
       )
     )
   }

--- a/scripts/gulp.env.debug.js
+++ b/scripts/gulp.env.debug.js
@@ -1,6 +1,7 @@
 const fs = require('fs')
 const minimist = require('minimist')
 
+const DEFAULT_INTERNAL_PASSWORD = '$YOUR_INTERNAL_PASSWORD'
 const DEFAULT_BP_PATH = '$YOUR_BP_PATH'
 const DEFAULT_ENV_VALUE = `
 # use this env file to modify env variables for debug purposes (see launch.json for more details)
@@ -9,6 +10,10 @@ BP_DATA_FOLDER=${DEFAULT_BP_PATH}/packages/bp/dist/data
 BP_MODULES_PATH=${DEFAULT_BP_PATH}/modules
 NLU_ENDPOINT=http://localhost:3200
 STUDIO_PORT=4000
+
+CORE_PORT=3000
+ROOT_PATH=''
+INTERNAL_PASSWORD=${DEFAULT_INTERNAL_PASSWORD}
 `
 
 const createEmptyEnvFileForDebugging = cb => {

--- a/scripts/gulp.env.debug.js
+++ b/scripts/gulp.env.debug.js
@@ -1,0 +1,34 @@
+const fs = require('fs')
+const minimist = require('minimist')
+
+const DEFAULT_BP_PATH = '$YOUR_BP_PATH'
+const DEFAULT_ENV_VALUE = `
+# use this env file to modify env variables for debug purposes (see launch.json for more details)
+
+BP_DATA_FOLDER=${DEFAULT_BP_PATH}/packages/bp/dist/data
+BP_MODULES_PATH=${DEFAULT_BP_PATH}/modules
+NLU_ENDPOINT=http://localhost:3200
+STUDIO_PORT=4000
+`
+
+const createEmptyEnvFileForDebugging = cb => {
+  const { location } = minimist(process.argv.slice(2))
+  if (!location) {
+    return cb(
+      new Error(
+        'Creating empty env file for debugging requires a the desired file location as 1st positional parameter.'
+      )
+    )
+  }
+
+  if (fs.existsSync(location)) {
+    return cb()
+  }
+
+  fs.writeFileSync(location, DEFAULT_ENV_VALUE)
+  return cb()
+}
+
+module.exports = {
+  createEmptyEnvFileForDebugging
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9767,7 +9767,7 @@ minimist-options@4.1.0:
 
 minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
   version "1.2.5"
-  resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
 minipass-collect@^1.0.2:


### PR DESCRIPTION
This PR does 2 things:

1. adds a launch.json file for debugging
2. create a default, git-ignored, `.env.debug` file to be used by `launch.json`

The `.env.debug` file allows a developer to change debug config without having to modify the git tracked `launch.json`
