### PR TITLE
fix(flow): fix ctrl + s toast text display

### DIFF
--- a/packages/studio-ui/src/web/views/FlowBuilder/index.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/index.tsx
@@ -136,7 +136,7 @@ const FlowBuilder = (props: Props) => {
     },
     save: e => {
       e.preventDefault()
-      toastInfo(lang.tr('studio.nowSaveAuto'), Timeout.LONG)
+      toastInfo(lang.tr('studio.flow.nowSaveAuto'), Timeout.LONG)
     },
     delete: e => {
       if (!utils.isInputFocused()) {
@@ -199,9 +199,7 @@ const FlowBuilder = (props: Props) => {
             }}
           />
         </div>
-        {!window.USE_ONEFLOW &&
-        <SidePanelInspector />
-        }
+        {!window.USE_ONEFLOW && <SidePanelInspector />}
       </div>
 
       <SkillsBuilder />


### PR DESCRIPTION
This PR fixes a translation when pressing Ctrl + S on the flow editor

**Before**

![Screenshot from 2021-09-30 11-34-44](https://user-images.githubusercontent.com/9640576/135486780-10ae33b6-d3ab-4f3c-947e-9f87d2841b3c.png)

**After**

![Screenshot from 2021-09-30 11-34-22](https://user-images.githubusercontent.com/9640576/135486808-77489238-9dfc-4598-9207-13d088926cdf.png)

Closes #99
And closes DEV-1705

