### PR TITLE
fix(ui-shared): Fix collapsible toggleExpand undef

### DIFF
--- a/packages/ui-shared-lite/Collapsible/index.tsx
+++ b/packages/ui-shared-lite/Collapsible/index.tsx
@@ -20,7 +20,7 @@ const Collapsible: FC<CollapsibleProps> = ({ opened, hidden, toggleExpand, name,
   const handleToggle = () => {
     const newValue = !isOpen
     setOpen(newValue)
-    toggleExpand(newValue)
+    toggleExpand && toggleExpand(newValue)
   }
 
   return (


### PR DESCRIPTION
The `toggleExpand` prop isn't always defined and is listed as optional in the typing, this causes a bug in HITL next