### PR TITLE
fix(studio): added form validation to bot settings page

### DIFF
--- a/packages/studio-ui/src/web/views/Config/index.tsx
+++ b/packages/studio-ui/src/web/views/Config/index.tsx
@@ -344,7 +344,13 @@ class ConfigView extends Component<Props, State> {
                   </div>
                 </FormGroup>
                 <FormGroup label={lang.tr('name')} labelFor="name">
-                  <InputGroup id="name" name="name" value={this.state.name} onChange={this.handleInputChanged} />
+                  <InputGroup
+                    id="name"
+                    name="name"
+                    value={this.state.name}
+                    maxLength={50}
+                    onChange={this.handleInputChanged}
+                  />
                 </FormGroup>
                 <FormGroup label={lang.tr('status')} labelFor="status">
                   <Select


### PR DESCRIPTION
This PR fixes an issue where it was possible to set a bot name with more than 50 chars which isn´t valid and throws a validation error in the front-end

Related to: https://github.com/botpress/botpress/pull/5524