### PR TITLE
fix(qna): add RTL content language support

### DIFF
--- a/packages/studio-ui/src/web/views/Qna/Components/QnA.tsx
+++ b/packages/studio-ui/src/web/views/Qna/Components/QnA.tsx
@@ -4,11 +4,12 @@ import { confirmDialog, lang, MoreOptions, MoreOptionsItems, toast, utils } from
 import cx from 'classnames'
 import { QnaItem } from 'common/typings'
 import _uniqueId from 'lodash/uniqueId'
-import React, { FC, Fragment, useState } from 'react'
+import React, { FC, Fragment, useMemo, useState } from 'react'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 import Select from 'react-select'
 
 import { getFlowLabel } from '~/components/Shared/Utils'
+import { isRTLLocale } from '~/translations'
 import style from '../style.scss'
 import { NEW_QNA_PREFIX } from '../utils/qnaList.utils'
 import ContextSelector from './ContextSelector'
@@ -54,6 +55,7 @@ const QnA: FC<Props> = props => {
   let answers = data.answers[contentLang]
   const refQuestions = contentLang !== defaultLanguage && data.questions[defaultLanguage]
   const refAnswers = contentLang !== defaultLanguage && data.answers[defaultLanguage]
+  const contentDirection = useMemo(() => (isRTLLocale(contentLang) ? 'rtl' : 'ltr'), [contentLang])
 
   if (refQuestions?.length > questions?.length || (!questions?.length && refQuestions?.length)) {
     questions = [...(questions || []), ...Array(refQuestions.length - (questions?.length || 0)).fill('')]
@@ -246,6 +248,7 @@ const QnA: FC<Props> = props => {
             itemListValidator={validateItemsList}
             placeholder={index => getPlaceholder('question', index)}
             label={lang.tr('qna.question')}
+            contentDirection={contentDirection}
             addItemLabel={lang.tr('qna.form.addQuestionAlternative')}
           />
           <TextAreaList
@@ -253,6 +256,7 @@ const QnA: FC<Props> = props => {
             items={answers || ['']}
             duplicateMsg={lang.tr('qna.form.duplicateAnswer')}
             itemListValidator={validateItemsList}
+            contentDirection={contentDirection}
             updateItems={items =>
               updateQnA({
                 id,

--- a/packages/studio-ui/src/web/views/Qna/Components/TextAreaList.tsx
+++ b/packages/studio-ui/src/web/views/Qna/Components/TextAreaList.tsx
@@ -1,4 +1,5 @@
 import { Button, Icon, Position, Tooltip } from '@blueprintjs/core'
+import { props } from 'bluebird'
 import { lang, ShortcutLabel, Textarea, utils } from 'botpress/shared'
 import cx from 'classnames'
 import _uniqueId from 'lodash/uniqueId'
@@ -17,13 +18,14 @@ interface Props {
   label: string
   refItems: string[]
   keyPrefix: string
+  contentDirection?: 'ltr' | 'rtl'
   showPicker?: boolean
   initialFocus?: string
   duplicateMsg?: string
   canAddContent?: boolean
 }
 
-const TextAreaList: FC<Props> = props => {
+const TextAreaList: FC<Props> = ({ contentDirection = 'ltr', ...props }) => {
   const [showPicker, setShowPicker] = useState(false)
   const [localItems, setLocalItems] = useState(props.items)
   // Generating unique keys so we don't need to rerender all the list as soon as we add or delete one element
@@ -99,6 +101,7 @@ const TextAreaList: FC<Props> = props => {
                 onBlur={() => updateItems(localItems)}
                 onKeyDown={e => onKeyDown(e, index)}
                 value={item}
+                direction={contentDirection}
               />
               {errors[index] && (
                 <div className={style.errorIcon}>

--- a/packages/ui-shared/src/Textarea/index.tsx
+++ b/packages/ui-shared/src/Textarea/index.tsx
@@ -17,7 +17,8 @@ const Textarea: FC<TextareaProps> = ({
   placeholder,
   onPaste,
   onBlur,
-  onKeyDown
+  onKeyDown,
+  direction = 'ltr'
 }) => {
   const [forceUpdate, setForceUpdate] = useState(false)
   const inputRef = useRef<HTMLTextAreaElement>(null)
@@ -64,7 +65,7 @@ const Textarea: FC<TextareaProps> = ({
     <Fragment>
       <textarea
         onPaste={onPaste}
-        style={{ height: `${height.current}px` }}
+        style={{ height: `${height.current}px`, direction }}
         ref={inputRef}
         className={cx(style.textarea, className)}
         value={value || refValue}

--- a/packages/ui-shared/src/Textarea/typings.d.ts
+++ b/packages/ui-shared/src/Textarea/typings.d.ts
@@ -10,5 +10,6 @@ export interface TextareaProps {
   onKeyDown?: (e?: SyntheticEvent) => void
   onPaste?: (e?: SyntheticEvent) => void
   refValue?: string
+  direction?: 'ltr' | 'rtl'
   value: string
 }


### PR DESCRIPTION
fixes #130 
We base ourselves on content language

Preview:
<img width="1737" alt="Screen Shot 2021-10-04 at 2 53 28 PM" src="https://user-images.githubusercontent.com/18604963/135908353-3c8b1aa5-c5b8-45f8-9670-6dda4886a532.png">

Waiting on confirmation from an arabic speaker to see if display is correct
