### PR TITLE
fix(ui): modify channel-vonage content-type warn

### DIFF
--- a/packages/studio-ui/src/web/components/ContentForm/index.tsx
+++ b/packages/studio-ui/src/web/components/ContentForm/index.tsx
@@ -104,17 +104,15 @@ const CustomDescriptionField = ({ description, id, formContext }: FieldProps) =>
   }
 
   if (id === 'root__description' && Object.keys(mapping).includes(formContext.subtype)) {
-    const capitalize = (str: string) => {
-      return str.charAt(0).toUpperCase() + str.slice(1)
-    }
-
     return (
       <div id={id} style={{ lineHeight: 'normal' }}>
         <div>
           <span className={localStyle.warning}>
             <Icon icon="warning-sign" />
-            &nbsp;Please note that {capitalize(formContext.subtype)} content-type is only supported in{' '}
-            {mapping[formContext.subtype].join(' and ')}
+            &nbsp;{' '}
+            {lang.tr('studio.content.contentTypeWarning', {
+              channels: mapping[formContext.subtype].join(', ')
+            })}
           </span>
         </div>
         <br />

--- a/packages/studio-ui/src/web/translations/en.json
+++ b/packages/studio-ui/src/web/translations/en.json
@@ -320,7 +320,8 @@
       "usageModal": {
         "contentUsage": "Content Usage",
         "node": "Node"
-      }
+      },
+      "contentTypeWarning": "Please note that this content-type is only supported in {channels}"
     },
     "flow": {
       "addNode": "Add Node",

--- a/packages/studio-ui/src/web/translations/es.json
+++ b/packages/studio-ui/src/web/translations/es.json
@@ -294,7 +294,8 @@
       "usageModal": {
         "contentUsage": "Uso de contenido",
         "node": "Nodo"
-      }
+      },
+      "contentTypeWarning": "Tenga en cuenta que este tipo de contenido solo es compatible con {channels}"
     },
     "flow": {
       "addNode": "Añadir nodo",

--- a/packages/studio-ui/src/web/translations/fr.json
+++ b/packages/studio-ui/src/web/translations/fr.json
@@ -316,7 +316,8 @@
       "usageModal": {
         "contentUsage": "Utilisation du contenu",
         "node": "Node"
-      }
+      },
+      "contentTypeWarning": "Veuillez noter que ce type de contenu n'est pris en charge qu'avec {channels}"
     },
     "flow": {
       "addNode": "Ajouter une node",


### PR DESCRIPTION
Small UI change, pretty self-explanatory.

Closes https://github.com/botpress/v12/issues/1441
closes: DEV-1568

Changed warning sign:
![Screenshot from 2021-10-06 17-35-04](https://user-images.githubusercontent.com/9640576/136286729-f2a70366-97c1-4de0-8b29-ff0296342c62.png)

![Screenshot from 2021-10-06 17-35-48](https://user-images.githubusercontent.com/9640576/136286735-35b49f22-2a50-4aaf-8cec-81d3096f59f6.png)
