### PR TITLE
fix: always display search bar on qna

### DIFF
--- a/packages/studio-ui/src/web/views/Qna/index.tsx
+++ b/packages/studio-ui/src/web/views/Qna/index.tsx
@@ -245,7 +245,7 @@ const QnAList: FC<Props> = props => {
         tabChange={setCurrentTab}
         tabs={tabs}
         buttons={buttons}
-        rightContent={items.length > 1 ? toolBarRightContent : null}
+        rightContent={toolBarRightContent}
       />
       <div className={cx(style.content, { [style.empty]: !items.length && !highlighted })}>
         {highlighted && (
@@ -266,7 +266,6 @@ const QnAList: FC<Props> = props => {
               defaultLanguage={defaultLanguage}
               deleteQnA={() => {
                 dispatch({ type: 'deleteQnA', data: { index: 'highlighted', bp } })
-
                 window.history.pushState(
                   window.history.state,
                   '',


### PR DESCRIPTION
## Description

I removed the condition to display the search bar. It's a pretty straightforward solution.

Fixes # (https://github.com/botpress/studio/issues/131)

## Type of change

- [X] Non Breaking change

## How has this been tested?

- [X] I performed a self-check of my changes on my local

**Test configuration**:
* BP version: 12.26.5
* Node version: 12.13.0
* OS: MacOS
* Browser: Chrome
* Binary or source ?: source

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I've included some media (picture/gif/video) if applicable to show the old and new behavior

## Media

![image](https://user-images.githubusercontent.com/13097764/136453912-272e09be-9a23-4125-a44a-00c1b45621f2.png)


