### PR TITLE
fix(qna): fix context search in QnA

### DIFF
--- a/packages/studio-ui/src/web/views/Qna/Components/ContextSelector.tsx
+++ b/packages/studio-ui/src/web/views/Qna/Components/ContextSelector.tsx
@@ -100,7 +100,7 @@ const ContextSelector: FC<Props> = props => {
         }}
         popoverProps={{ minimal: true, fill: true, usePortal: false }}
         selectedItems={contexts}
-        createNewItemRenderer={!props.isSearch && createNewItemRenderer}
+        createNewItemRenderer={props.isSearch ? undefined : createNewItemRenderer}
         createNewItemFromQuery={q => q}
       />
     </div>


### PR DESCRIPTION
This PR fixes an issue with QnA, where searching for QnAs by context would result in a rendering issue.

Since the old condition (`!props.isSearch && createNewItemRenderer`) would return `false` when `isSearch` is true and that the component (which expect a function or undefined for its prop `createNewItemRenderer`) tries to interpret `false` as a function ts would result in a `TypeError: i.props.createNewItemRenderer is not a function` error.

**Before**

![Screenshot from 2021-10-18 11-05-29](https://user-images.githubusercontent.com/9640576/137758110-5e5e97b0-7979-4f46-b627-731bdb0d149a.png)

**After**

![Screenshot from 2021-10-18 11-06-29](https://user-images.githubusercontent.com/9640576/137758108-1c7f5dac-9f9b-4c8a-bd31-05e7850974df.png)

Fixes https://github.com/botpress/v12/issues/1504
Closes DEV-1877