### PR TITLE
fix(qna): avoid adding new item by pressing enter during composing with IME

### DIFF
--- a/packages/studio-ui/src/web/views/Qna/Components/TextAreaList.tsx
+++ b/packages/studio-ui/src/web/views/Qna/Components/TextAreaList.tsx
@@ -54,7 +54,7 @@ const TextAreaList: FC<Props> = ({ contentDirection = 'ltr', ...props }) => {
       updateLocalItem(index, localItems[index] + '\n')
     }
 
-    if (e.key === 'Enter') {
+    if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
       e.preventDefault()
       addItem()
     }


### PR DESCRIPTION
This fixes https://github.com/botpress/botpress/issues/3062

Before
![134074270-456ff2a6-baa3-40c6-a15c-3411c888e761](https://user-images.githubusercontent.com/935341/138577046-725ea24d-ae95-4e72-b2dc-12fb301d11ea.gif)

After
![2021-10-24 10-58-27 2021-10-24 10_59_50](https://user-images.githubusercontent.com/935341/138577057-c1a29dd9-34ae-4004-8e4a-8e8b4b99b612.gif)

