### PR TITLE
fix(skills): dialog overflow on too many params, fixes #149

### DIFF
--- a/packages/studio-ui/src/web/views/FlowBuilder/nodeProps/parameters.scss
+++ b/packages/studio-ui/src/web/views/FlowBuilder/nodeProps/parameters.scss
@@ -1,6 +1,7 @@
 .key input {
   padding: 5px;
   border: solid 1px #ddd;
+  height: 32px;
 }
 
 .invalid input {
@@ -15,6 +16,10 @@
 
   input {
     width: 100%;
+  }
+
+  tbody {
+    overflow-y: overlay;
   }
 
   margin-bottom: 0;

--- a/packages/ui-shared/src/Dialog/style.scss
+++ b/packages/ui-shared/src/Dialog/style.scss
@@ -5,8 +5,9 @@
 .dialog {
   max-height: 90%;
   background-color: white !important;
+  overflow-y: scroll;
 
-  :global(.bp3-dialog-body){
+  :global(.bp3-dialog-body) {
     overflow: auto;
   }
 


### PR DESCRIPTION
https://linear.app/botpress/issue/DEV-1956/[bug]-ui-issue-when-using-multiple-arguments-in-an-action

This PR requires a fix in the main repo as well  (PR coming)

## Before
<img width="640" alt="image" src="https://user-images.githubusercontent.com/1315508/139677005-849969ef-0bd7-4e48-89ba-3a7baf31b55e.png">

## After

<img width="633" alt="image" src="https://user-images.githubusercontent.com/1315508/139676006-291a1b48-31e5-4aad-ad10-e1def6fc1e85.png">

<img width="637" alt="image" src="https://user-images.githubusercontent.com/1315508/139676108-b2ef07d3-4f81-456d-bfbb-9e1c3d9a5f0e.png">
