### PR TITLE
Fixed regex for matching text and _ 

### DIFF
--- a/packages/studio-ui/src/web/views/FlowBuilder/utils/general.util.ts
+++ b/packages/studio-ui/src/web/views/FlowBuilder/utils/general.util.ts
@@ -1,1 +1,1 @@
-export const ROUTER_CONDITON_REGEX = /(.*)\.([a-zA-Z0-9]+)(.*)/
+export const ROUTER_CONDITON_REGEX = /(.*)\.([a-zA-Z0-9_]+)(.*)/


### PR DESCRIPTION
Fixes issue #104 
And closes DEV-1913

The problem was relying upon a regex that didn't match underscore. 

Before 
![image](https://user-images.githubusercontent.com/30974685/139684265-5837bf9e-9e40-4097-9a83-f3850052df28.png)

After : 
![image](https://user-images.githubusercontent.com/30974685/139684322-89d60228-b899-4366-8fc2-74705758179d.png)

And in botpress : 

https://user-images.githubusercontent.com/9640576/139689566-dfdfeda8-6122-4a30-a893-de0bd2afed40.mp4

