### PR TITLE
fix: CallAPI Transition Edit Not Persisted

### DIFF
--- a/packages/studio-ui/src/web/views/FlowBuilder/nodeProps/ConditionModalForm.jsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/nodeProps/ConditionModalForm.jsx
@@ -47,7 +47,7 @@ class ConditionModalForm extends Component {
 
     const { item } = this.props
     const condition = (item && item.condition) || ''
-    const conditionType = this.getConditionType(condition)
+    const conditionType = (item && item.conditionType) || this.getConditionType(condition)
 
     if (item && item.node) {
       let typeOfTransition = item.node.indexOf('.') !== -1 ? 'subflow' : 'node'
@@ -182,7 +182,11 @@ class ConditionModalForm extends Component {
 
     // replace: "{{stuff}} more stuff... {{other stuff}}" by "stuff more stuff... other stuff"
     const condition = this.state.condition.replace(/({{)(.*?)(}})/g, '$2')
-    const payload = { caption: this.props.item && this.props.item.caption, condition }
+    const payload = {
+      caption: this.props.item && this.props.item.caption,
+      condition,
+      conditionType: this.state.conditionType
+    }
 
     if (this.state.typeOfTransition === 'subflow') {
       const node = this.state.flowToSubflowNode


### PR DESCRIPTION
Linear issue: DEV-1260

This fixes https://github.com/botpress/botpress/issues/4571 

https://www.awesomescreenshot.com/video/5854955?key=8bdc26c0b9070f9c41ed66f19e42f1a9

Fix is to save a new field in the `flow.json` named `conditionType` instead of inferring it at load time. 

New `Flow.json` : 
![image](https://user-images.githubusercontent.com/30974685/139695430-8b740e60-2c32-4c01-a8ac-4846356a9df1.png)

Note: The one transition added with this new behavior has a `"conditionType": "raw"` field. 
It is not breaking and backward compatible. 
 

Note 2 : 
This does not migrate actions! 

The old behavior was : "Create a raw action" => "Type is badly inferred to MatchedProps" 
New behavior: "Create a raw action" => "Save it and load it as raw action"

New behavior for old actions "Load it: as there is no `conditionType` infer type (e.g load a MatchedProps), save it as MatchedProps". If the user wanted to change it to a raw action he need to do it by hand as we cannot magically know the real type of each action.  