### PR TITLE
fix(studio): no ghost flows when deleting a bot

### DIFF
--- a/packages/studio-be/src/core/bots/bot-service.ts
+++ b/packages/studio-be/src/core/bots/bot-service.ts
@@ -13,6 +13,7 @@ import { inject, injectable, postConstruct, tagged } from 'inversify'
 import Joi from 'joi'
 import _ from 'lodash'
 import path from 'path'
+import { BOTPRESS_EVENTS } from 'process'
 
 const BOT_CONFIG_FILENAME = 'bot.config.json'
 const BOT_ID_PLACEHOLDER = '/bots/BOT_ID_PLACEHOLDER/'
@@ -285,6 +286,7 @@ export class BotService {
     }
 
     await this.cms.clearElementsFromCache(botId)
+    BOTPRESS_EVENTS.emit('unmountBot', { botId })
 
     BotService._mountedBots.set(botId, false)
 

--- a/packages/studio-be/src/core/dialog/flow/flow-service.ts
+++ b/packages/studio-be/src/core/dialog/flow/flow-service.ts
@@ -17,6 +17,7 @@ import { Memoize } from 'lodash-decorators'
 import LRUCache from 'lru-cache'
 import moment from 'moment'
 import ms from 'ms'
+import { BOTPRESS_EVENTS } from 'process'
 import { NLUService } from 'studio/nlu'
 import { QNAService } from 'studio/qna'
 
@@ -79,6 +80,10 @@ export class FlowService {
     await AppLifecycle.waitFor(AppLifecycleEvents.CONFIGURATION_LOADED)
 
     this.invalidateFlow = <any>await this.jobService.broadcast<void>(this._localInvalidateFlow.bind(this))
+
+    BOTPRESS_EVENTS.on('unmountBot', ({ botId }) => {
+      delete this.scopes[botId]
+    })
   }
 
   private _localInvalidateFlow(botId: string, key: string, flow?: FlowView, newKey?: string) {

--- a/packages/studio-be/src/index.ts
+++ b/packages/studio-be/src/index.ts
@@ -1,5 +1,6 @@
 global['NativePromise'] = global.Promise
 
+import EventEmitter from 'events'
 import fs from 'fs'
 import path from 'path'
 import yn from 'yn'
@@ -45,6 +46,8 @@ if (process.env.APP_DATA_PATH) {
 }
 
 process.IS_FAILSAFE = yn(process.env.BP_FAILSAFE) || false
+process.BOTPRESS_EVENTS = new EventEmitter()
+process.BOTPRESS_EVENTS.setMaxListeners(1000)
 process.LOADED_MODULES = {}
 
 process.STUDIO_LOCATION = process.pkg


### PR DESCRIPTION
When you delete a bot, flows in the studio are not cleared correctly so they stayed in memory and were displayed if you re-created a bot with the same id.

This is a quick workaround to cleanup correctly 

Fixes https://linear.app/botpress/issue/DEV-1670/[bug]-deleted-bots-not-being-deleted-properly-botpressbotpress-5393****