### PR TITLE
fix(studio): fix the smartinput suggestions cursor in contentform

### DIFF
--- a/packages/studio-ui/src/web/components/ContentForm/Text.tsx
+++ b/packages/studio-ui/src/web/components/ContentForm/Text.tsx
@@ -30,7 +30,7 @@ const Text: FC<Props> = props => {
       <div className={style.innerWrapper}>
         <SmartInput
           key={key.current}
-          singleLine={false}
+          singleLine={uiSchema.$subtype !== 'textarea'}
           value={formData}
           onChange={onChange}
           className={style.textarea}

--- a/packages/studio-ui/src/web/components/ContentForm/Text.tsx
+++ b/packages/studio-ui/src/web/components/ContentForm/Text.tsx
@@ -15,13 +15,8 @@ interface Props {
 }
 
 const Text: FC<Props> = props => {
-  const [value, setValue] = useState('')
   const { formContext, formData, schema, required, uiSchema, onChange } = props
   const key = useRef(`${formContext?.customKey}`)
-
-  useEffect(() => {
-    setValue(formData)
-  }, [formData])
 
   useEffect(() => {
     key.current = `${formContext?.customKey}`
@@ -35,13 +30,13 @@ const Text: FC<Props> = props => {
       <div className={style.innerWrapper}>
         <SmartInput
           key={key.current}
-          singleLine={uiSchema.$subtype !== 'textarea'}
-          value={value}
+          singleLine={false}
+          value={formData}
           onChange={onChange}
           className={style.textarea}
           isSideForm
         />
-        {isMissingCurlyBraceClosure(value) && (
+        {isMissingCurlyBraceClosure(formData) && (
           <p className={style.fieldError}>{lang.tr('studio.content.missingClosingCurlyBrace')}</p>
         )}
       </div>

--- a/packages/studio-ui/src/web/components/SmartInput/index.tsx
+++ b/packages/studio-ui/src/web/components/SmartInput/index.tsx
@@ -42,7 +42,7 @@ class SmartInput extends React.Component<ConnectedProps, State> {
   editor: any
 
   mentionOptions = {
-    mentionTrigger: '{', // The character that will trigger the auto-complete to show up
+    mentionTrigger: '{{', // The character that will trigger the auto-complete to show up
     mentionRegExp: '{?[\\d\\w\\.]*}{0,2}', // Combined with mentionTrigger's "{", this looks for "{{something.like.this}}"
     entityMutability: 'MUTABLE' // Mutable means the user will be able to delete and add characters to this entity once tagged
   }


### PR DESCRIPTION
fixes #49
https://linear.app/botpress/issue/DEV-1429/[bug]-typing-opening-braces-causes-jump-in-caret-botpressstudio-49

This was happening in a very specific scenario.. which is when you use the SmartInput in a content form of type Text (but not array).  This happened for the basic/text content-type.

## Before
![2021-11-01 12 00 28](https://user-images.githubusercontent.com/1315508/139702091-782640c9-2ad9-4d94-a808-dfc0df06fa92.gif)

## After
![2021-11-01 11 58 42](https://user-images.githubusercontent.com/1315508/139701905-0088fb62-06a9-4194-9d85-85320bd2c6ab.gif)


