### PR TITLE
fix(debugger): Voice-Content Type in Emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Currently, it is not recommended to run the studio on its own. Therefore, you mu
 Like before, any changes made on the frontend will be available after a simple page refresh. Changes on the backend will require a server restart.
 
 Since this package MUST be started from the Botpress Server, you need to set a special environment variable on the server so it can load the correct files.
-The variable is named `DEV_STUDIO_PATH` and must point to `packages/studio-be/out`
+The variable is named `DEV_STUDIO_PATH` and must point to `packages/studio-be/out`. Watch out, path must be an abs path, env var doesn't support relative path.
 
 ## As standalone (NOT RECOMMENDED)
 

--- a/packages/studio-ui/src/web/components/Layout/BottomPanel/Debugger/views/Summary.tsx
+++ b/packages/studio-ui/src/web/components/Layout/BottomPanel/Debugger/views/Summary.tsx
@@ -42,9 +42,9 @@ export default class Summary extends React.Component<Props> {
         <Dialog
           suggestions={this.props.event.suggestions}
           decision={this.props.event.decision}
-          stacktrace={this.props.event.state?.__stacktrace || []}
+          stacktrace={this.props.event?.state?.__stacktrace || []}
         />
-        <NLU session={this.props.event.state?.session || {}} nluData={this.props.event.nlu} />
+        <NLU session={this.props.event?.state?.session || {}} nluData={this.props.event.nlu} />
 
         {this.props.event.ndu && (
           <Fragment>

--- a/packages/studio-ui/src/web/components/Layout/BottomPanel/Debugger/views/Summary.tsx
+++ b/packages/studio-ui/src/web/components/Layout/BottomPanel/Debugger/views/Summary.tsx
@@ -44,7 +44,7 @@ export default class Summary extends React.Component<Props> {
           decision={this.props.event.decision}
           stacktrace={this.props.event?.state?.__stacktrace || []}
         />
-        <NLU session={this.props.event?.state?.session || {}} nluData={this.props.event.nlu} />
+        <NLU session={this.props.event.state?.session || {}} nluData={this.props.event.nlu} />
 
         {this.props.event.ndu && (
           <Fragment>


### PR DESCRIPTION
Closes DEV-5465
Closes https://github.com/botpress/botpress/issues/5465

from the original issue screenshot a null check was missing.  

![image](https://user-images.githubusercontent.com/30974685/139708436-1aa6682b-d071-4658-86bf-03f5dd25ed87.png)

Inspecting messages works fine.