### PR TITLE
fix(qna): Stop new qna line on enter press on IME input

### DIFF
--- a/packages/studio-ui/src/web/views/Qna/Components/TextAreaList.tsx
+++ b/packages/studio-ui/src/web/views/Qna/Components/TextAreaList.tsx
@@ -3,7 +3,7 @@ import { props } from 'bluebird'
 import { lang, ShortcutLabel, Textarea, utils } from 'botpress/shared'
 import cx from 'classnames'
 import _uniqueId from 'lodash/uniqueId'
-import React, { FC, Fragment, useEffect, useRef, useState } from 'react'
+import React, { FC, Fragment, useEffect, useRef, useState, KeyboardEvent } from 'react'
 
 import BotpressContentTypePicker from '~/components/Content/Select'
 import BotpressContentPicker from '~/components/Content/Select/Widget'
@@ -49,7 +49,12 @@ const TextAreaList: FC<Props> = ({ contentDirection = 'ltr', ...props }) => {
     updateItems(localItems)
   }
 
-  const onKeyDown = (e: KeyboardEvent, index: number): void => {
+  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>, index: number): void => {
+    if (e.nativeEvent.isComposing && e.key === 'Enter') {
+      e.preventDefault()
+      e.stopPropagation()
+      return
+    }
     if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
       updateLocalItem(index, localItems[index] + '\n')
     }


### PR DESCRIPTION
Q&A input would create a new question when pressing enter on IME input:

## Before

https://user-images.githubusercontent.com/18604963/139714233-f6ed5c00-0588-4f55-ad81-a52e216f8ae9.mov

## After

https://user-images.githubusercontent.com/18604963/139714266-ea6993c6-16b8-4b7b-8bb2-ba1c380d4b24.mov

Fixes https://github.com/botpress/botpress/issues/3062

