### PR TITLE
DEV-1421: Fix rename node

### DIFF
--- a/packages/studio-ui/src/web/views/FlowBuilder/inspector/index.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/inspector/index.tsx
@@ -84,7 +84,9 @@ class Inspector extends Component<Props> {
 
     const updateNodeAndRefresh = (...args) => {
       updateFlowNode(...args)
-      refreshFlowsLinks()
+      setImmediate(() => {
+        refreshFlowsLinks()
+      })
     }
 
     if (nodeType === 'skill-call') {


### PR DESCRIPTION
https://linear.app/botpress/issue/DEV-1421/[bug]-link-between-node-is-deconnected-when-a-node-is-renam

https://user-images.githubusercontent.com/6981314/139719808-52ab210f-f53b-4676-91aa-9f0e59184e49.mov

e