### PR TITLE
fix(studio): CMS crashes on new language translation

### DIFF
--- a/packages/studio-ui/src/web/views/Content/List.tsx
+++ b/packages/studio-ui/src/web/views/Content/List.tsx
@@ -235,7 +235,7 @@ class ListView extends Component<Props, State> {
         filterable: false,
         Cell: x => {
           const preview = x.original.previews?.[this.props.contentLang]
-          const className = cx({ [style.missingTranslation]: preview.startsWith('(missing translation) ') })
+          const className = cx({ [style.missingTranslation]: !preview || preview.startsWith('(missing translation) ') })
           return (
             <React.Fragment>
               <span className={className}>


### PR DESCRIPTION
fixes #139 
https://linear.app/botpress/issue/DEV-1911/[bug]-cms-not-loading-when-zh-language-is-selected-botpressstudio-139

When you add a new language to a bot then try to load the CMS in that new language, the CMS will fail to render.

This happens because the CMS needs to refresh the content elements for that bot after saving the config.

Although this PR fixes it, a more robust fix that would prevent restarting the server would be to invalidate the CMS.. but it didn't seem necessary IMO as this seems to be the only place where it crashes and it fixes it.