### PR TITLE
fix(studio): show webchat by default

### DIFF
--- a/packages/studio-ui/src/web/components/Layout/index.tsx
+++ b/packages/studio-ui/src/web/components/Layout/index.tsx
@@ -63,7 +63,7 @@ const Layout: FC<Props> = (props: Props) => {
         return // event is not coming from emulator
       }
 
-      if (message.data.name === 'webchatLoaded' && utils.storage.get(WEBCHAT_PANEL_STATUS) === 'opened') {
+      if (message.data.name === 'webchatLoaded' && utils.storage.get(WEBCHAT_PANEL_STATUS) !== 'closed') {
         toggleEmulator()
       }
 


### PR DESCRIPTION
The emulator webchat is displayed by default instead of hidden by default.. which makes more sense for new users