### PR TITLE
fix(studio): warns user about double braces

### DIFF
--- a/packages/studio-ui/src/web/components/ContentForm/UploadWidget/UrlUpload.tsx
+++ b/packages/studio-ui/src/web/components/ContentForm/UploadWidget/UrlUpload.tsx
@@ -1,9 +1,10 @@
-import { Button, Intent, Position, Tooltip } from '@blueprintjs/core'
+import { Button, Icon, Intent, Position, Tooltip } from '@blueprintjs/core'
 import { lang, FileDisplay, UploadFieldProps } from 'botpress/shared'
 import React, { FC, Fragment, useEffect, useState } from 'react'
 import SmartInput from '~/components/SmartInput'
 import style from '~/views/FlowBuilder/sidePanelTopics/form/style.scss'
 
+import parentStyle from '../style.scss'
 import localStyle from './style.scss'
 
 interface IUrlUploadProps {
@@ -42,6 +43,8 @@ const UrlUpload: FC<IUrlUploadProps> = props => {
     return re.test(str)
   }
 
+  const urlHasDoubleBraces = new RegExp('(^|[^{]){{[^{]', 'g').test(url)
+
   return (
     <div className={style.fieldWrapper}>
       {value && isUrlOrRelativePath(value) && <FileDisplay url={value} type={type} onDelete={onDelete} deletable />}
@@ -66,6 +69,15 @@ const UrlUpload: FC<IUrlUploadProps> = props => {
               {lang.tr('ok')}
             </Button>
           </div>
+          {urlHasDoubleBraces && (
+            <div>
+              <span className={parentStyle.warning}>
+                <Icon icon="warning-sign" />
+
+                {lang.tr('studio.content.tripleBracesWarning')}
+              </span>
+            </div>
+          )}
         </Fragment>
       )}
     </div>

--- a/packages/studio-ui/src/web/translations/en.json
+++ b/packages/studio-ui/src/web/translations/en.json
@@ -307,7 +307,8 @@
         "contentUsage": "Content Usage",
         "node": "Node"
       },
-      "contentTypeWarning": "Please note that this content-type is only supported in {channels}"
+      "contentTypeWarning": "Please note that this content-type is only supported in {channels}",
+      "tripleBracesWarning": "To add unescaped / raw text here, use {{{...}}} instead of {{...}}"
     },
     "flow": {
       "addNode": "Add Node",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/87815239/139727668-4e9b156d-5e3b-4c1c-8b41-ed3c827209da.png)
(the warning message is added)

Really simple. Doesn't attempt to standardize everything, but instead warns user when content requires triple braces. 

The use case is when a user gets an image / file / video link from somewhere, and needs to display it. 