### PR TITLE
fix(studio): can't lose the bottom debugger panel because of window resize anymore

### DIFF
--- a/packages/studio-ui/src/web/components/Layout/index.tsx
+++ b/packages/studio-ui/src/web/components/Layout/index.tsx
@@ -189,6 +189,15 @@ const Layout: FC<Props> = (props: Props) => {
   const bottomPanelHeight = props.bottomPanelExpanded ? EXPANDED_PANEL_HEIGHT : lastSize
   const bottomBarSize = props.bottomPanel ? bottomPanelHeight : '100%'
 
+  const squashSize = size => {
+    if (typeof size === 'string') return size
+    const maxSize = 100
+    const minSize = window.innerHeight - 100
+    size = Math.max(maxSize, size)
+    size = Math.min(minSize, size)
+    return size
+  }
+
   return (
     <Fragment>
       <HotKeys handlers={keyHandlers} id="mainLayout" className={layout.mainLayout}>
@@ -202,9 +211,9 @@ const Layout: FC<Props> = (props: Props) => {
           />
           <SplitPane
             split={'horizontal'}
-            defaultSize={lastSize}
-            onChange={size => size > 100 && localStorage.setItem(splitPanelLastSizeKey, size.toString())}
-            size={bottomBarSize}
+            defaultSize={squashSize(lastSize)}
+            onChange={size => size > 100 && localStorage.setItem(splitPanelLastSizeKey, squashSize(size).toString())}
+            size={squashSize(bottomBarSize)}
             maxSize={-100}
             className={cx(layout.mainSplitPaneWToolbar, {
               'emulator-open': props.emulatorOpen

--- a/packages/studio-ui/src/web/components/Layout/index.tsx
+++ b/packages/studio-ui/src/web/components/Layout/index.tsx
@@ -63,7 +63,7 @@ const Layout: FC<Props> = (props: Props) => {
         return // event is not coming from emulator
       }
 
-      if (message.data.name === 'webchatLoaded' && utils.storage.get(WEBCHAT_PANEL_STATUS) === 'opened') {
+      if (message.data.name === 'webchatLoaded' && utils.storage.get(WEBCHAT_PANEL_STATUS) !== 'closed') {
         toggleEmulator()
       }
 

--- a/packages/studio-ui/src/web/components/Layout/index.tsx
+++ b/packages/studio-ui/src/web/components/Layout/index.tsx
@@ -190,7 +190,10 @@ const Layout: FC<Props> = (props: Props) => {
   const bottomBarSize = props.bottomPanel ? bottomPanelHeight : '100%'
 
   const squashSize = size => {
-    if (typeof size === 'string') return size
+    if (typeof size === 'string') {
+      return size
+    }
+
     const maxSize = 100
     const minSize = window.innerHeight - 100
     size = Math.max(maxSize, size)


### PR DESCRIPTION
If you resized the debugger panel then came back in a smaller window size, the panel would be out of the screen and impossible to get back without clearing your localStorage.

This happened to me all the time...

## Before

![2021-11-01 15 23 57](https://user-images.githubusercontent.com/1315508/139729824-a3de7b0b-bc81-4466-ad39-bed9226b5a0d.gif)

## After

![2021-11-01 15 25 14](https://user-images.githubusercontent.com/1315508/139729817-4736dab9-0892-47f8-b0e9-165784c05e9f.gif)


