### PR TITLE
chore(debugger): fix missing translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Currently, it is not recommended to run the studio on its own. Therefore, you mu
 Like before, any changes made on the frontend will be available after a simple page refresh. Changes on the backend will require a server restart.
 
 Since this package MUST be started from the Botpress Server, you need to set a special environment variable on the server so it can load the correct files.
-The variable is named `DEV_STUDIO_PATH` and must point to `packages/studio-be/out`
+The variable is named `DEV_STUDIO_PATH` and must point to `packages/studio-be/out`. Watch out, path must be an abs path, env var doesn't support relative path.
 
 ## As standalone (NOT RECOMMENDED)
 

--- a/packages/studio-ui/src/web/components/Layout/BottomPanel/Debugger/views/Dialog.tsx
+++ b/packages/studio-ui/src/web/components/Layout/BottomPanel/Debugger/views/Dialog.tsx
@@ -54,7 +54,7 @@ const Dialog: FC<Props> = props => {
       </ContentSection>
 
       {props.suggestions?.length > 0 && (
-        <ContentSection title={lang.tr('studio.bottomPanel.debugger.dialog.dialogManager')} className={style.section}>
+        <ContentSection title={lang.tr('bottomPanel.debugger.dialog.dialogManager')} className={style.section}>
           <Suggestions suggestions={props.suggestions} />
         </ContentSection>
       )}


### PR DESCRIPTION
This PR fixes a missing translation in the debugger

Fixes https://github.com/botpress/studio/issues/169
Closes DEV-1961


**Before**

<img width="576" alt="Screen Shot 2021-09-28 at 2 39 26 PM" src="https://user-images.githubusercontent.com/9640576/139729117-63848989-f4aa-4f11-b6f9-0a39ab251561.png">

**After**

![Screenshot from 2021-11-01 16-07-27](https://user-images.githubusercontent.com/9640576/139734758-075a71d4-3321-4245-b4be-def8538c0640.png)
