### PR TITLE
fix(studio): missing translation in debugger panel

### DIFF
--- a/packages/studio-ui/src/web/components/Layout/BottomPanel/Debugger/views/Dialog.tsx
+++ b/packages/studio-ui/src/web/components/Layout/BottomPanel/Debugger/views/Dialog.tsx
@@ -54,7 +54,7 @@ const Dialog: FC<Props> = props => {
       </ContentSection>
 
       {props.suggestions?.length > 0 && (
-        <ContentSection title={lang.tr('studio.bottomPanel.debugger.dialog.dialogManager')} className={style.section}>
+        <ContentSection title={lang.tr('bottomPanel.debugger.dialog.dialogManager')} className={style.section}>
           <Suggestions suggestions={props.suggestions} />
         </ContentSection>
       )}


### PR DESCRIPTION
There was a missing translation in the debugger that didn't look professional and bugged me for a while.

## Before

![image](https://user-images.githubusercontent.com/1315508/139731274-a9d2fbe7-de01-40f6-af4b-0172457fd0a4.png)


## After

![image](https://user-images.githubusercontent.com/1315508/139731179-0c5a05f3-a1d4-4c88-be5b-6f9e49598071.png)
