### PR TITLE
fix(studio): Node Action overwrite flushing data

### DIFF
--- a/packages/studio-ui/src/web/views/FlowBuilder/nodeProps/ParametersTable.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/nodeProps/ParametersTable.tsx
@@ -138,7 +138,7 @@ export default class ParametersTable extends Component<Props, State> {
       const keyClass = classnames(style.key, { [style.invalid]: !isKeyValid, [style.mandatory]: definition.required })
 
       return (
-        <tr key={id}>
+        <tr key={`${id}_${paramValue}`}>
           <td className={keyClass}>
             {help}
             <input type="text" disabled={!!definition.required} value={paramName} onChange={editKey} />


### PR DESCRIPTION
Closes: DEV-1371
Fixes: https://github.com/botpress/botpress/issues/5107

### Describe the bug
When changing an action to a new action, the completed fields are lost.

### Here's the result

![Animation](https://user-images.githubusercontent.com/10071388/139732111-16c7b92e-a8e0-4b87-9d59-b98b5db24998.gif)
