### PR TITLE
fix: hardcoded query in context dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Currently, it is not recommended to run the studio on its own. Therefore, you mu
 Like before, any changes made on the frontend will be available after a simple page refresh. Changes on the backend will require a server restart.
 
 Since this package MUST be started from the Botpress Server, you need to set a special environment variable on the server so it can load the correct files.
-The variable is named `DEV_STUDIO_PATH` and must point to `packages/studio-be/out`
+The variable is named `DEV_STUDIO_PATH` and must point to `packages/studio-be/out`. Watch out, path must be an abs path, env var doesn't support relative path.
 
 ## As standalone (NOT RECOMMENDED)
 

--- a/packages/studio-ui/src/web/views/Nlu/intents/ContextSelector.tsx
+++ b/packages/studio-ui/src/web/views/Nlu/intents/ContextSelector.tsx
@@ -54,7 +54,7 @@ export const ContextSelector: FC<Props> = props => {
   const createNewItemRenderer = (query: string, active: boolean, handleClick) => (
     <MenuItem
       icon="plus"
-      text={lang.tr('nlu.intents.contextSelectorCreateMissing')}
+      text={(lang.tr('nlu.intents.contextSelectorCreateMissing'), { query })}
       active={active}
       onClick={handleClick}
       shouldDismissPopover={false}

--- a/packages/studio-ui/src/web/views/Nlu/intents/ContextSelector.tsx
+++ b/packages/studio-ui/src/web/views/Nlu/intents/ContextSelector.tsx
@@ -54,7 +54,7 @@ export const ContextSelector: FC<Props> = props => {
   const createNewItemRenderer = (query: string, active: boolean, handleClick) => (
     <MenuItem
       icon="plus"
-      text={(lang.tr('nlu.intents.contextSelectorCreateMissing'), { query })}
+      text={lang.tr('nlu.intents.contextSelectorCreateMissing', { query })}
       active={active}
       onClick={handleClick}
       shouldDismissPopover={false}


### PR DESCRIPTION
Closes DEV-1963
Closes https://github.com/botpress/botpress/issues/5638

Fix was to add the missing value parameter in `tr()`

![image](https://user-images.githubusercontent.com/30974685/139735337-4ad25eb9-7b4f-41d7-a0b4-d9eb4182746d.png)
