### PR TITLE
dev-1034 Part 1: subdomain media URL

### DIFF
--- a/packages/studio-be/src/common/url.ts
+++ b/packages/studio-be/src/common/url.ts
@@ -1,5 +1,5 @@
 export const isBpUrl = (str: string): boolean => {
-  const re = /^\/api\/.*\/bots\/.*\/media\/.*/g
+  const re = /^api\/.*\/bots\/.*\/media\/.*/g
 
   return re.test(str)
 }

--- a/packages/studio-be/src/core/media/providers/ghost-media-service.ts
+++ b/packages/studio-be/src/core/media/providers/ghost-media-service.ts
@@ -50,9 +50,9 @@ export class GhostMediaService implements MediaService {
     // make sure the file name is a valid URI
     fileName = encodeURIComponent(fileName)
     if (this.botId) {
-      return `/api/v1/bots/${this.botId}/media/${fileName}`
+      return `api/v1/bots/${this.botId}/media/${fileName}`
     } else {
-      return `/api/v1/media/${fileName}`
+      return `api/v1/media/${fileName}`
     }
   }
 }


### PR DESCRIPTION
## Description

Fixing the paths when `EXTERNAL_URL` is set

Fixes # Issue 1034 on Linear

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

Depends on pull request on Botpress/botpress

