### PR TITLE
fix(studio): display error when no nlu modelId

### DIFF
--- a/packages/studio-be/src/sdk/botpress.d.ts
+++ b/packages/studio-be/src/sdk/botpress.d.ts
@@ -539,7 +539,6 @@ declare module 'botpress/sdk' {
     export interface EventUnderstanding {
       readonly errored: boolean
       readonly modelId: string | undefined
-      
       readonly predictions?: {
         [context: string]: {
           confidence: number

--- a/packages/studio-be/src/sdk/botpress.d.ts
+++ b/packages/studio-be/src/sdk/botpress.d.ts
@@ -538,7 +538,8 @@ declare module 'botpress/sdk' {
 
     export interface EventUnderstanding {
       readonly errored: boolean
-
+      readonly modelId: string | undefined
+      
       readonly predictions?: {
         [context: string]: {
           confidence: number

--- a/packages/studio-ui/src/web/components/Layout/BottomPanel/Debugger/views/NLU.tsx
+++ b/packages/studio-ui/src/web/components/Layout/BottomPanel/Debugger/views/NLU.tsx
@@ -20,6 +20,12 @@ const NLU: FC<{ nluData: sdk.IO.EventUnderstanding; session: any }> = ({ nluData
     <Fragment>
       <ContentSection title={lang.tr('bottomPanel.debugger.nlu.languageUnderstanding')} className={style.section}>
         <div>
+          {!nluData?.modelId?.length && (
+            <span style={{ color: Colors.RED3 }}>
+              <Icon icon="warning-sign" color={Colors.RED3} />
+              <strong>&nbsp;{lang.tr('bottomPanel.debugger.nlu.noModel')}</strong>
+            </span>
+          )}
           {nluData.ambiguous && (
             <Tooltip
               position={Position.TOP}

--- a/packages/studio-ui/src/web/components/Layout/BottomPanel/index.tsx
+++ b/packages/studio-ui/src/web/components/Layout/BottomPanel/index.tsx
@@ -100,7 +100,7 @@ const BottomPanel = props => {
 
   return (
     <div className={style.container}>
-      <Tabs className={style.verticalTab} vertical onChange={tab => handleChangeTab(tab)} selectedTabId={tab}>
+      <Tabs className={style.verticalTab} vertical onChange={tab => handleChangeTab(tab as string)} selectedTabId={tab}>
         <Tab id="debugger" title={lang.tr('debugger')} />
         <Tab id="logs" title={lang.tr('logs')} />
         {props.inspectorEnabled && <Tab id="inspector" title={lang.tr('inspector')} />}

--- a/packages/studio-ui/src/web/translations/en.json
+++ b/packages/studio-ui/src/web/translations/en.json
@@ -660,6 +660,7 @@
         "intentsVeryClose": "Predicted intents are very close.",
         "youCanAccountForIt": "You can account for it checking the variable : ",
         "ambiguous": "Ambiguous",
+        "noModel": "Failed at running NLU as no model was trained",
         "languageUnderstanding": "Language Understanding"
       },
       "slots": {

--- a/packages/studio-ui/src/web/translations/es.json
+++ b/packages/studio-ui/src/web/translations/es.json
@@ -634,6 +634,7 @@
         "intentsVeryClose": "Los intentos previstos están muy cerca",
         "youCanAccountForIt": "Puede contabilizarlo marcando la variable:",
         "ambiguous": "Ambiguous",
+        "noModel": "No se pudo ejecutar NLU porque no se entrenó ningún modelo",
         "languageUnderstanding": "Comprensión del lenguaje"
       },
       "slots": {

--- a/packages/studio-ui/src/web/translations/fr.json
+++ b/packages/studio-ui/src/web/translations/fr.json
@@ -656,6 +656,7 @@
         "intentsVeryClose": "Les intentions prévues sont très proches.",
         "youCanAccountForIt": "Vous pouvez en rendre compte en vérifiant la variable : ",
         "ambiguous": "Ambigu",
+        "noModel": "Échec d'évaluation NLU car aucun modèle n'est disponible",
         "languageUnderstanding": "Compréhension du langage"
       },
       "slots": {


### PR DESCRIPTION
## Description

When you have no NLU model trained and you use the webchat, it was difficult to know why the predicted intent was "None".. this confused some users in the past. 

I made it obvious that when no NLU model was used for the prediction, that we display an error in the Debugger in the Language Understanding section.

![image](https://user-images.githubusercontent.com/1315508/139751673-1f0d5f6b-bee1-4e9a-9764-918a33ecc490.png)

## Dependency

**This branch depends on the `sp_no_nlu` branch in botpress/botpress**