### PR TITLE
chore(debugger): send new session message to debugger

### DIFF
--- a/packages/studio-ui/src/web/components/Layout/BottomPanel/Debugger/index.tsx
+++ b/packages/studio-ui/src/web/components/Layout/BottomPanel/Debugger/index.tsx
@@ -163,7 +163,7 @@ export class Debugger extends React.Component<Props, State> {
 
   handleNewSession = () => {
     const userId = nanoid(20)
-    this.postToIframe('change-user-id', userId)
+    this.postToIframe('new-session', null)
   }
 
   handleTabChange = selectedTabId => this.setState({ selectedTabId })

--- a/packages/studio-ui/src/web/components/Layout/BottomPanel/Debugger/index.tsx
+++ b/packages/studio-ui/src/web/components/Layout/BottomPanel/Debugger/index.tsx
@@ -162,7 +162,6 @@ export class Debugger extends React.Component<Props, State> {
   }
 
   handleNewSession = () => {
-    const userId = nanoid(20)
     this.postToIframe('new-session', null)
   }
 


### PR DESCRIPTION
This PR is related to https://github.com/botpress/botpress/pull/5591 

It changes the way new sessions are created from the debugger by posting a `new-session` message instead of a `change-user-id` one.