### PR TITLE
chore(dev): new migration mechanism

### DIFF
--- a/packages/studio-be/package.json
+++ b/packages/studio-be/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "start": "cd ./out && cross-env NODE_PATH=./ cross-env BP_MODULES_PATH=B:/bp18/modules node index.js",
-    "build": "yarn clean && yarn tsc",
+    "build": "yarn tsc",
     "clean": "node ./node_modules/rimraf/bin.js ./out",
     "watch": "yarn tsc --watch"
   },

--- a/packages/studio-be/src/core/app/botpress.ts
+++ b/packages/studio-be/src/core/app/botpress.ts
@@ -137,8 +137,7 @@ export class Botpress {
       }`
     )
 
-    const maxConcurrentMount = parseInt(process.env.MAX_CONCURRENT_MOUNT || '5')
-    await Promise.map(botsToMount, botId => this.botService.mountBot(botId), { concurrency: maxConcurrentMount })
+    await Promise.map(botsToMount, botId => this.botService.mountBot(botId))
   }
 
   private async initializeServices() {

--- a/packages/studio-be/src/core/bpfs/ghost-service.ts
+++ b/packages/studio-be/src/core/bpfs/ghost-service.ts
@@ -334,11 +334,11 @@ export class ScopedGhostService {
     return (await this.readFileAsBuffer(rootFolder, file)).toString()
   }
 
-  async readFileAsObject<T>(rootFolder: string, file: string): Promise<T> {
+  async readFileAsObject<T>(rootFolder: string, file: string, options?: { noCache: boolean }): Promise<T> {
     const fileName = this._normalizeFileName(rootFolder, file)
     const cacheKey = this.objectCacheKey(fileName)
 
-    if (!(await this.cache.has(cacheKey))) {
+    if (!(await this.cache.has(cacheKey)) || options?.noCache) {
       const value = await this.readFileAsString(rootFolder, file)
       let obj
       try {
@@ -350,7 +350,11 @@ export class ScopedGhostService {
           throw new Error(`SyntaxError in your JSON: ${file}: \n ${e}`)
         }
       }
-      await this.cache.set(cacheKey, obj)
+
+      if (!options?.noCache) {
+        await this.cache.set(cacheKey, obj)
+      }
+
       return obj
     }
 

--- a/packages/studio-be/src/core/migration/bot-migration-service.ts
+++ b/packages/studio-be/src/core/migration/bot-migration-service.ts
@@ -95,8 +95,9 @@ export class BotMigrationService {
 
     logger.warn(this.writeLabel(migrations.length, botId, configVersion))
 
-    await Promise.mapSeries(migrations, async ({ filename, info }) => {
-      const label = `${types[info.type]} - ${info.description}`
+    await Promise.mapSeries(migrations, async ({ filename, info }, idx) => {
+      const isLast = idx === migrations.length - 1
+      const label = `${types[info.type]} - ${info.description} ${isLast ? '\n' : ''}`
 
       try {
         const result = await this.migService.loadedMigrations[filename].up(opts)
@@ -114,7 +115,6 @@ export class BotMigrationService {
       }
     })
 
-    logger.warn('')
     if (hasFailures) {
       return this.logger.error(`[${botId}] Could not complete bot migration. It may behave unexpectedly.`)
     }

--- a/packages/studio-be/src/core/migration/bot-migration-service.ts
+++ b/packages/studio-be/src/core/migration/bot-migration-service.ts
@@ -105,7 +105,7 @@ export class BotMigrationService {
 
         if (result.success) {
           logger.warn(`${chalk.green('[success]')} ${label}`)
-        } else if (result.hasChanges) {
+        } else {
           logger.error(`${chalk.red('[failure]')} ${label}: ${result.message || ''}`)
           hasFailures = true
         }

--- a/packages/studio-be/src/core/migration/bot-migration-service.ts
+++ b/packages/studio-be/src/core/migration/bot-migration-service.ts
@@ -69,7 +69,10 @@ export class BotMigrationService {
           return migration
         }
       } catch (err) {
-        return migration
+        this.logger
+          .forBot(botId)
+          .attachError(err)
+          .error(`There was an error while processing migration ${migration.title} for bot ${botId}`)
       }
     })
 

--- a/packages/studio-be/src/core/migration/bot-migration-service.ts
+++ b/packages/studio-be/src/core/migration/bot-migration-service.ts
@@ -103,14 +103,12 @@ export class BotMigrationService {
           logger.warn(`${chalk.green('[success]')} ${label}`)
         } else if (result.hasChanges) {
           logger.error(`${chalk.red('[failure]')} ${label}: ${result.message || ''}`)
+          hasFailures = true
         }
-
-        return
       } catch (err) {
         logger.attachError(err).error(`${chalk.red('[failure]')} ${label}`)
+        hasFailures = true
       }
-
-      hasFailures = true
     })
 
     logger.warn('')

--- a/packages/studio-be/src/migrations/v12_0_1-1562193005-migrate_numeral_entities_to_number.ts
+++ b/packages/studio-be/src/migrations/v12_0_1-1562193005-migrate_numeral_entities_to_number.ts
@@ -14,7 +14,7 @@ const migration: Migration = {
     const intents = await bpfs.directoryListing('./intents', '*.json')
 
     for (const file of intents) {
-      const content = (await bpfs.readFileAsObject('./intents', file)) as sdk.NLU.IntentDefinition
+      const content = (await bpfs.readFileAsObject('./intents', file, { noCache: true })) as sdk.NLU.IntentDefinition
 
       content.slots = content.slots.map(slot => {
         if (slot.entities?.find(entity => entity === 'numeral')) {

--- a/packages/studio-be/src/migrations/v12_0_1-1562193005-migrate_numeral_entities_to_number.ts
+++ b/packages/studio-be/src/migrations/v12_0_1-1562193005-migrate_numeral_entities_to_number.ts
@@ -30,7 +30,7 @@ const migration: Migration = {
       }
     }
 
-    return { success: true, hasChanges }
+    return isDryRun ? { hasChanges } : { success: true }
   }
 }
 

--- a/packages/studio-be/src/migrations/v12_0_1-1562193005-migrate_numeral_entities_to_number.ts
+++ b/packages/studio-be/src/migrations/v12_0_1-1562193005-migrate_numeral_entities_to_number.ts
@@ -1,38 +1,36 @@
 import * as sdk from 'botpress/sdk'
-import { Migration, MigrationOpts } from 'core/migration'
+import { Migration, MigrationOpts, MigrationResult } from 'core/migration'
 
 const migration: Migration = {
   info: {
     description: 'Migrates slots from type numeral to number',
     target: 'bot',
-    type: 'config'
+    type: 'content'
   },
-  up: async ({ botService, ghostService, metadata }: MigrationOpts): Promise<sdk.MigrationResult> => {
-    const updateBot = async (botId: string) => {
-      const bpfs = ghostService.forBot(botId)
-      const intents = await bpfs.directoryListing('./intents', '*.json')
-      for (const file of intents) {
-        const content = (await bpfs.readFileAsObject('./intents', file)) as sdk.NLU.IntentDefinition
-        content.slots = content.slots.map(slot => {
-          if (slot.entities && slot.entities.length) {
-            slot.entities = slot.entities.map(entity => (entity === 'numeral' ? 'number' : entity))
-          }
-          return slot
-        })
+  up: async ({ ghostService, metadata: { botId, isDryRun } }: MigrationOpts): Promise<MigrationResult> => {
+    let hasChanges = false
+
+    const bpfs = ghostService.forBot(botId)
+    const intents = await bpfs.directoryListing('./intents', '*.json')
+
+    for (const file of intents) {
+      const content = (await bpfs.readFileAsObject('./intents', file)) as sdk.NLU.IntentDefinition
+
+      content.slots = content.slots.map(slot => {
+        if (slot.entities?.find(entity => entity === 'numeral')) {
+          hasChanges = true
+          slot.entities = slot.entities.map(entity => (entity === 'numeral' ? 'number' : entity))
+        }
+
+        return slot
+      })
+
+      if (!isDryRun) {
         await bpfs.upsertFile('./intents', file, JSON.stringify(content, undefined, 2), { ignoreLock: true })
       }
     }
 
-    if (metadata.botId) {
-      await updateBot(metadata.botId)
-    } else {
-      const bots = await botService.getBots()
-      for (const botId of Array.from(bots.keys())) {
-        await updateBot(botId)
-      }
-    }
-
-    return { success: true, message: 'Slots migrated successfully' }
+    return { success: true, hasChanges }
   }
 }
 

--- a/packages/studio-be/src/migrations/v12_10_0-1591119240-migrate_content_in_flow_data_for_ndu_bots.ts
+++ b/packages/studio-be/src/migrations/v12_10_0-1591119240-migrate_content_in_flow_data_for_ndu_bots.ts
@@ -3,7 +3,7 @@ import { FlowView } from 'common/typings'
 import { TYPES } from 'core/app/types'
 import { ScopedGhostService } from 'core/bpfs'
 import { FlowService } from 'core/dialog'
-import { Migration, MigrationOpts } from 'core/migration'
+import { Migration, MigrationOpts, MigrationResult } from 'core/migration'
 import _ from 'lodash'
 
 const CONTENT_DIR = 'content-elements'
@@ -67,7 +67,7 @@ const migration: Migration = {
     logger,
     inversify,
     metadata: { botId, isDryRun }
-  }: MigrationOpts): Promise<sdk.MigrationResult> => {
+  }: MigrationOpts): Promise<MigrationResult> => {
     let hasChanges = false
     const flowService = inversify.get<FlowService>(TYPES.FlowService)
 
@@ -103,7 +103,7 @@ const migration: Migration = {
       }
     })
 
-    return { success: true, hasChanges }
+    return isDryRun ? { hasChanges } : { success: true }
   }
 }
 

--- a/packages/studio-be/src/migrations/v12_1_3-1567534454-bots_error_handling_flow.ts
+++ b/packages/studio-be/src/migrations/v12_1_3-1567534454-bots_error_handling_flow.ts
@@ -78,9 +78,11 @@ const migration: Migration = {
         JSON.stringify([...existingElements, getErrorElement(botConfig.defaultLanguage)], undefined, 2),
         { ignoreLock: true }
       )
+
+      return { success: true }
     }
 
-    return { success: true, hasChanges: true }
+    return { hasChanges: true }
   }
 }
 

--- a/packages/studio-be/src/migrations/v12_21_1-1618260400-bot_content_type_update.ts
+++ b/packages/studio-be/src/migrations/v12_21_1-1618260400-bot_content_type_update.ts
@@ -1,5 +1,4 @@
-import * as sdk from 'botpress/sdk'
-import { Migration, MigrationOpts } from 'core/migration'
+import { Migration, MigrationOpts, MigrationResult } from 'core/migration'
 import _ from 'lodash'
 
 const migration: Migration = {
@@ -8,10 +7,7 @@ const migration: Migration = {
     target: 'bot',
     type: 'config'
   },
-  up: async ({
-    configProvider,
-    metadata: { botId, botConfig, isDryRun }
-  }: MigrationOpts): Promise<sdk.MigrationResult> => {
+  up: async ({ configProvider, metadata: { botId, botConfig, isDryRun } }: MigrationOpts): Promise<MigrationResult> => {
     let hasChanges = false
 
     const newTypes = ['builtin_video', 'builtin_audio']
@@ -30,7 +26,7 @@ const migration: Migration = {
       }
     }
 
-    return { success: true, hasChanges }
+    return isDryRun ? { hasChanges } : { success: true }
   },
   down: async () => {
     // Down migrations not necessary for content types, no impact

--- a/packages/studio-be/src/migrations/v12_22_1-1621260400-add_file_and_location_content_type_bot_config.ts
+++ b/packages/studio-be/src/migrations/v12_22_1-1621260400-add_file_and_location_content_type_bot_config.ts
@@ -1,5 +1,4 @@
-import * as sdk from 'botpress/sdk'
-import { Migration, MigrationOpts } from 'core/migration'
+import { Migration, MigrationOpts, MigrationResult } from 'core/migration'
 import _ from 'lodash'
 
 const migration: Migration = {
@@ -8,7 +7,7 @@ const migration: Migration = {
     target: 'bot',
     type: 'config'
   },
-  up: async ({ configProvider, metadata }: MigrationOpts): Promise<sdk.MigrationResult> => {
+  up: async ({ configProvider, metadata }: MigrationOpts): Promise<MigrationResult> => {
     const { botId, botConfig, isDryRun } = metadata
 
     let hasChanges = false
@@ -27,7 +26,7 @@ const migration: Migration = {
       }
     }
 
-    return { success: true, hasChanges }
+    return isDryRun ? { hasChanges } : { success: true }
   },
   down: async () => {
     // Down migrations not necessary for content types, no impact

--- a/packages/studio-be/src/migrations/v12_2_3-1573576448-updated_entities.ts
+++ b/packages/studio-be/src/migrations/v12_2_3-1573576448-updated_entities.ts
@@ -20,7 +20,10 @@ const migration: Migration = {
     const entFiles = await bpfs.directoryListing('./entities', '*.json')
 
     for (const fileName of entFiles) {
-      const entityDef = (await bpfs.readFileAsObject('./entities', fileName)) as sdk.NLU.EntityDefinition
+      const entityDef = (await bpfs.readFileAsObject('./entities', fileName, {
+        noCache: true
+      })) as sdk.NLU.EntityDefinition
+
       if (entityDef.type === 'pattern') {
         if (entityDef.matchCase === undefined) {
           hasChanges = true

--- a/packages/studio-be/src/migrations/v12_2_3-1573576448-updated_entities.ts
+++ b/packages/studio-be/src/migrations/v12_2_3-1573576448-updated_entities.ts
@@ -52,7 +52,7 @@ const migration: Migration = {
       }
     }
 
-    return { success: true, hasChanges }
+    return isDryRun ? { hasChanges } : { success: true }
   },
 
   down: async ({ logger }: MigrationOpts): Promise<MigrationResult> => {

--- a/packages/studio-be/src/migrations/v12_2_3-1573576448-updated_entities.ts
+++ b/packages/studio-be/src/migrations/v12_2_3-1573576448-updated_entities.ts
@@ -1,5 +1,5 @@
 import * as sdk from 'botpress/sdk'
-import { Migration, MigrationOpts } from 'core/migration'
+import { Migration, MigrationOpts, MigrationResult } from 'core/migration'
 import path from 'path'
 
 const FuzzyTolerance = {
@@ -14,46 +14,48 @@ const migration: Migration = {
     target: 'bot',
     type: 'content'
   },
-  up: async ({ botService, ghostService, metadata }: MigrationOpts): Promise<sdk.MigrationResult> => {
-    const migrateBotEntities = async (botId: string) => {
-      const bpfs = ghostService.forBot(botId)
-      const entFiles = await bpfs.directoryListing('./entities', '*.json')
-      for (const fileName of entFiles) {
-        const entityDef = (await bpfs.readFileAsObject('./entities', fileName)) as sdk.NLU.EntityDefinition
-        if (entityDef.type === 'pattern') {
-          if (entityDef.matchCase === undefined) {
-            entityDef.matchCase = false
-          }
-          if (entityDef.examples === undefined) {
-            entityDef.examples = []
-          }
+  up: async ({ ghostService, metadata: { botId, isDryRun } }: MigrationOpts): Promise<MigrationResult> => {
+    let hasChanges = false
+    const bpfs = ghostService.forBot(botId)
+    const entFiles = await bpfs.directoryListing('./entities', '*.json')
+
+    for (const fileName of entFiles) {
+      const entityDef = (await bpfs.readFileAsObject('./entities', fileName)) as sdk.NLU.EntityDefinition
+      if (entityDef.type === 'pattern') {
+        if (entityDef.matchCase === undefined) {
+          hasChanges = true
+          entityDef.matchCase = false
+        }
+        if (entityDef.examples === undefined) {
+          hasChanges = true
+          entityDef.examples = []
+        }
+      }
+
+      if (entityDef.type === 'list') {
+        if (typeof entityDef.fuzzy !== 'number') {
+          hasChanges = true
         }
 
-        if (entityDef.type === 'list') {
-          if (entityDef.fuzzy) {
-            entityDef.fuzzy = FuzzyTolerance.Medium
-          } else {
-            entityDef.fuzzy = FuzzyTolerance.Strict
-          }
+        if (entityDef.fuzzy) {
+          entityDef.fuzzy = FuzzyTolerance.Medium
+        } else {
+          entityDef.fuzzy = FuzzyTolerance.Strict
         }
+      }
 
+      if (!isDryRun) {
         await bpfs.upsertFile('./entities', fileName, JSON.stringify(entityDef, undefined, 2), { ignoreLock: true })
       }
     }
-    if (metadata.botId) {
-      await migrateBotEntities(metadata.botId)
-    } else {
-      const bots = await botService.getBots()
-      await Promise.map(bots.keys(), botId => migrateBotEntities(botId))
-    }
 
-    return { success: true, message: "Entities' fields updated successfully" }
+    return { success: true, hasChanges }
   },
 
-  down: async ({ logger }: MigrationOpts): Promise<sdk.MigrationResult> => {
+  down: async ({ logger }: MigrationOpts): Promise<MigrationResult> => {
     logger.warn(`No down migration written for ${path.basename(__filename)}`)
     return {
-      success: true,
+      hasChanges: false,
       message: 'No down migration written.'
     }
   }

--- a/packages/studio-be/src/migrations/v12_3_2-1577993749-entities_misspelling.ts
+++ b/packages/studio-be/src/migrations/v12_3_2-1577993749-entities_misspelling.ts
@@ -21,17 +21,17 @@ const migration: Migration = {
 
       if (entityDef['occurences']) {
         hasChanges = true
-      }
 
-      entityDef.occurrences = _.cloneDeep(entityDef['occurences'])
-      delete entityDef['occurences']
+        entityDef.occurrences = _.cloneDeep(entityDef['occurences'])
+        delete entityDef['occurences']
 
-      if (!isDryRun) {
-        await bpfs.upsertFile('./entities', fileName, JSON.stringify(entityDef, undefined, 2), { ignoreLock: true })
+        if (!isDryRun) {
+          await bpfs.upsertFile('./entities', fileName, JSON.stringify(entityDef, undefined, 2), { ignoreLock: true })
+        }
       }
     }
 
-    return { success: true, hasChanges }
+    return isDryRun ? { hasChanges } : { success: true }
   },
 
   down: async ({ logger }: MigrationOpts): Promise<MigrationResult> => {

--- a/packages/studio-be/src/migrations/v12_3_2-1577993749-entities_misspelling.ts
+++ b/packages/studio-be/src/migrations/v12_3_2-1577993749-entities_misspelling.ts
@@ -15,7 +15,10 @@ const migration: Migration = {
     const entFiles = await bpfs.directoryListing('./entities', '*.json')
 
     for (const fileName of entFiles) {
-      const entityDef = (await bpfs.readFileAsObject('./entities', fileName)) as sdk.NLU.EntityDefinition
+      const entityDef = (await bpfs.readFileAsObject('./entities', fileName, {
+        noCache: true
+      })) as sdk.NLU.EntityDefinition
+
       if (entityDef['occurences']) {
         hasChanges = true
       }

--- a/packages/studio-be/src/migrations/v12_5_0-1577776334-text-markdown.ts
+++ b/packages/studio-be/src/migrations/v12_5_0-1577776334-text-markdown.ts
@@ -1,5 +1,5 @@
 import * as sdk from 'botpress/sdk'
-import { Migration, MigrationOpts } from 'core/migration'
+import { Migration, MigrationOpts, MigrationResult } from 'core/migration'
 
 const ELEMENTS_DIR = 'content-elements'
 
@@ -9,7 +9,7 @@ const migration: Migration = {
     target: 'bot',
     type: 'content'
   },
-  up: async ({ ghostService, metadata: { botId, isDryRun } }: MigrationOpts): Promise<sdk.MigrationResult> => {
+  up: async ({ ghostService, metadata: { botId, isDryRun } }: MigrationOpts): Promise<MigrationResult> => {
     let hasChanges = false
     const checkFile = (fileContent: string, nbElements: number) => {
       const parsed = JSON.parse(fileContent)
@@ -54,7 +54,7 @@ const migration: Migration = {
       }
     }
 
-    return { success: true, hasChanges }
+    return isDryRun ? { hasChanges } : { success: true }
   }
 }
 

--- a/packages/studio-be/src/migrations/v12_5_0-1577776334-text-markdown.ts
+++ b/packages/studio-be/src/migrations/v12_5_0-1577776334-text-markdown.ts
@@ -35,7 +35,10 @@ const migration: Migration = {
 
     for (const fileName of entFiles) {
       try {
-        const contentElements = await bpfs.readFileAsObject<sdk.ContentElement[]>(ELEMENTS_DIR, fileName)
+        const contentElements = await bpfs.readFileAsObject<sdk.ContentElement[]>(ELEMENTS_DIR, fileName, {
+          noCache: true
+        })
+
         contentElements.forEach(element => updateFormData(element))
 
         const fileContent = JSON.stringify(contentElements, undefined, 2)

--- a/packages/studio-be/src/migrations/v12_7_1-1583507028-prune_and_compress_models.ts
+++ b/packages/studio-be/src/migrations/v12_7_1-1583507028-prune_and_compress_models.ts
@@ -114,7 +114,7 @@ const migration: Migration = {
 
       return Promise.map(modNames, async mod => {
         try {
-          const model: any = await ghost.readFileAsObject(MODELS_DIR, mod)
+          const model: any = await ghost.readFileAsObject(MODELS_DIR, mod, { noCache: true })
           hasChanges = true
 
           if (!isDryRun) {

--- a/packages/studio-be/src/migrations/v12_7_1-1583507028-prune_and_compress_models.ts
+++ b/packages/studio-be/src/migrations/v12_7_1-1583507028-prune_and_compress_models.ts
@@ -114,10 +114,10 @@ const migration: Migration = {
 
       return Promise.map(modNames, async mod => {
         try {
+          const model: any = await ghost.readFileAsObject(MODELS_DIR, mod)
           hasChanges = true
 
           if (!isDryRun) {
-            const model: any = await ghost.readFileAsObject(MODELS_DIR, mod)
             if (!model.hash) {
               return ghost.deleteFile(MODELS_DIR, mod) // model is really outdated
             }

--- a/packages/studio-be/src/migrations/v12_8_0-1583933939-qna_multi_contexts.ts
+++ b/packages/studio-be/src/migrations/v12_8_0-1583933939-qna_multi_contexts.ts
@@ -14,7 +14,7 @@ const migration: Migration = {
     const files = await bpfs.directoryListing('./qna', '*.json')
 
     for (const file of files) {
-      const content = (await bpfs.readFileAsObject('./qna', file)) as any
+      const content = (await bpfs.readFileAsObject('./qna', file, { noCache: true })) as any
       const { contexts, category } = content.data
 
       if (contexts === undefined) {

--- a/packages/studio-be/src/migrations/v12_8_0-1583933939-qna_multi_contexts.ts
+++ b/packages/studio-be/src/migrations/v12_8_0-1583933939-qna_multi_contexts.ts
@@ -1,5 +1,4 @@
-import * as sdk from 'botpress/sdk'
-import { Migration, MigrationOpts } from 'core/migration'
+import { Migration, MigrationOpts, MigrationResult } from 'core/migration'
 
 const migration: Migration = {
   info: {
@@ -7,7 +6,7 @@ const migration: Migration = {
     target: 'bot',
     type: 'content'
   },
-  up: async ({ ghostService, metadata: { botId, isDryRun } }: MigrationOpts): Promise<sdk.MigrationResult> => {
+  up: async ({ ghostService, metadata: { botId, isDryRun } }: MigrationOpts): Promise<MigrationResult> => {
     let hasChanges = false
 
     const bpfs = ghostService.forBot(botId)
@@ -29,7 +28,7 @@ const migration: Migration = {
       }
     }
 
-    return { success: true, hasChanges }
+    return isDryRun ? { hasChanges } : { success: true }
   }
 }
 


### PR DESCRIPTION
The migration mechanism is wobbly and unreliable. It relies on versions stored in config files or in the database which sometimes are not in sync, it's complicated to test new migrations. Before implementing this on the main repository, i'm adding it to the studio since there is way less migrations and the process is already a mess, anyway.

When you mount a bot, it will try to run all migrations in a "dry run" state. In that mode, they don't save any changes, but they return a true/false value if they were about to save something.

Then, we can display the migration label and list migrations that needs to be executed in a compact and more concise way, ex:
![image](https://user-images.githubusercontent.com/42552874/141340552-a26b4545-082e-4c28-b4ce-157112a7ec5e.png)

Previously, it would display this:
![image](https://user-images.githubusercontent.com/42552874/141341193-9d3925b8-8c74-4b3d-bb6b-af941aab7b40.png)
