### PR TITLE
feat(cloud): support cloud-ready options in bot config

### DIFF
--- a/packages/studio-be/src/core/bots/bot-service.ts
+++ b/packages/studio-be/src/core/bots/bot-service.ts
@@ -63,7 +63,9 @@ const BotCreationSchema = Joi.object().keys({
       id: Joi.string()
     }
   },
-  locked: Joi.bool()
+  locked: Joi.bool(),
+  isCloudBot: Joi.bool().optional(),
+  bpCloudApiKey: Joi.string().optional()
 })
 
 const debug = DEBUG('services:bots')

--- a/packages/studio-be/src/core/bots/bot-service.ts
+++ b/packages/studio-be/src/core/bots/bot-service.ts
@@ -67,8 +67,8 @@ const BotCreationSchema = Joi.object().keys({
   isCloudBot: Joi.bool().optional(),
   cloud: Joi.object({
     oauthUrl: Joi.string().uri(),
-    clientId: Joi.string().guid(),
-    clientSecret: Joi.string().min(1)
+    clientId: Joi.string().allow(''),
+    clientSecret: Joi.string().allow('')
   }).optional()
 })
 

--- a/packages/studio-be/src/core/bots/bot-service.ts
+++ b/packages/studio-be/src/core/bots/bot-service.ts
@@ -65,7 +65,11 @@ const BotCreationSchema = Joi.object().keys({
   },
   locked: Joi.bool(),
   isCloudBot: Joi.bool().optional(),
-  bpCloudApiKey: Joi.string().optional()
+  cloud: Joi.object({
+    oauthUrl: Joi.string().optional(),
+    clientId: Joi.string().optional(),
+    clientSecret: Joi.string().optional()
+  }).optional()
 })
 
 const debug = DEBUG('services:bots')

--- a/packages/studio-be/src/core/bots/bot-service.ts
+++ b/packages/studio-be/src/core/bots/bot-service.ts
@@ -66,9 +66,9 @@ const BotCreationSchema = Joi.object().keys({
   locked: Joi.bool(),
   isCloudBot: Joi.bool().optional(),
   cloud: Joi.object({
-    oauthUrl: Joi.string().optional(),
-    clientId: Joi.string().optional(),
-    clientSecret: Joi.string().optional()
+    oauthUrl: Joi.string().uri(),
+    clientId: Joi.string().guid(),
+    clientSecret: Joi.string().guid()
   }).optional()
 })
 

--- a/packages/studio-be/src/core/bots/bot-service.ts
+++ b/packages/studio-be/src/core/bots/bot-service.ts
@@ -68,7 +68,7 @@ const BotCreationSchema = Joi.object().keys({
   cloud: Joi.object({
     oauthUrl: Joi.string().uri(),
     clientId: Joi.string().guid(),
-    clientSecret: Joi.string().guid()
+    clientSecret: Joi.string().min(1)
   }).optional()
 })
 


### PR DESCRIPTION
https://linear.app/botpress/issue/DEV-2026/a-user-can-enter-cloud-ready-options-when-creating-a-bot-on-the-admin

Support writing `bot.config.json` with cloud-ready options

### Related PRs

- https://github.com/botpress/typings/pull/2
- https://github.com/botpress/botpress/pull/5704