### PR TITLE
chore(dx): run prerelease task only when pr is ready for review

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Extract Informations
         id: info
-        uses: botpress/gh-actions/extract_info@master
+        uses: botpress/gh-actions/extract_info@v1
         with:
           branch: ${{ steps.branch.outputs.branch_name }}
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -30,7 +30,7 @@ jobs:
         id: info
         uses: botpress/gh-actions/extract_info@master
         with:
-          branch: ${{ github.ref_head }}
+          branch: ${{ env.GITHUB_HEAD_REF }}
 
       - name: Debug
         run: |

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Debug
         run: |
           echo if this action succeeds a binary will be available at
-          echo head branch is ${{ env.GITHUB_HEAD_REF }}
+          echo head branch is ${GITHUB_HEAD_REF}
           echo s3://botpress-dev-bins/studio/${{ steps.info.outputs.branch_sanitized }}
 
       - name: Checkout Code

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -30,7 +30,7 @@ jobs:
         id: info
         uses: botpress/gh-actions/extract_info@master
         with:
-          branch: ${GITHUB_HEAD_REF}
+          branch: ${{ github.ref_head }}
 
       - name: Debug
         run: |

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -77,7 +77,7 @@ jobs:
         run: yarn package
 
       - name: Rename Binary Files
-        uses: botpress/gh-actions/rename_binaries@fl_fix_prerelease
+        uses: botpress/gh-actions/rename_binaries@master
         with:
           subname: ${{ steps.info.outputs.branch_sanitized }}
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -26,11 +26,16 @@ jobs:
     name: Build and Publish Binaries
     runs-on: ubuntu-latest
     steps:
+      - name: Get Branch Name
+        id: branch
+        run: |
+          echo "::set-output name=branch_name::$(echo ${GITHUB_HEAD_REF})"
+
       - name: Extract Informations
         id: info
         uses: botpress/gh-actions/extract_info@master
         with:
-          branch: ${{ env.GITHUB_HEAD_REF }}
+          branch: ${{ steps.branch.outputs.branch_name }}
 
       - name: Debug
         run: |

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -26,10 +26,17 @@ jobs:
     name: Build and Publish Binaries
     runs-on: ubuntu-latest
     steps:
+      - name: Extract Informations
+        id: info
+        uses: botpress/gh-actions/extract_info@master
+        with:
+          branch: ${GITHUB_HEAD_REF}
+
       - name: Debug
         run: |
-          echo if this action succeeds a bin will be available at
-          echo s3://botpress-dev-bins/studio/${GITHUB_HEAD_REF}
+          echo if this action succeeds a binary will be available at
+          echo s3://botpress-dev-bins/studio/${{ steps.info.outputs.branch_sanitized }}
+
       - name: Checkout Code
         uses: actions/checkout@master
 
@@ -65,11 +72,13 @@ jobs:
         run: yarn package
 
       - name: Rename Binary Files
-        uses: botpress/gh-actions/rename_binaries@master
+        uses: botpress/gh-actions/rename_binaries@fl_fix_prerelease
+        with:
+          subname: ${{ steps.info.outputs.branch_sanitized }}
 
       - name: Publish Binaries
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          aws s3 sync bin s3://botpress-dev-bins/studio/${GITHUB_HEAD_REF}
+          aws s3 sync bin s3://botpress-dev-bins/studio/${{ steps.info.outputs.branch_sanitized }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -40,7 +40,6 @@ jobs:
       - name: Debug
         run: |
           echo if this action succeeds a binary will be available at
-          echo head branch is ${GITHUB_HEAD_REF}
           echo s3://botpress-dev-bins/studio/${{ steps.info.outputs.branch_sanitized }}
 
       - name: Checkout Code

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,13 +1,35 @@
 name: Pre-Release
 on:
   pull_request:
-    types: [review_requested]
+    types:
+      [
+        assigned,
+        unassigned,
+        labeled,
+        unlabeled,
+        opened,
+        edited,
+        closed,
+        reopened,
+        synchronize,
+        converted_to_draft,
+        ready_for_review,
+        locked,
+        unlocked,
+        review_requested,
+        review_request,
+      ]
 
 jobs:
   pre_release_bin:
+    if: github.event.pull_request.draft == false
     name: Build and Publish Binaries
     runs-on: ubuntu-latest
     steps:
+      - name: Debug
+        run: |
+          echo if this action succeeds a bin will be available at
+          echo s3://botpress-dev-bins/studio/${GITHUB_HEAD_REF}
       - name: Checkout Code
         uses: actions/checkout@master
 
@@ -24,7 +46,6 @@ jobs:
       - name: Install Tools
         run: |
           pip install awscli
-
       - name: Git Unshallow
         run: git fetch --prune --unshallow
 
@@ -43,10 +64,6 @@ jobs:
       - name: Package Binaries
         run: yarn package
 
-      - name: Extract Informations
-        id: info
-        uses: botpress/gh-actions/extract_info@master
-
       - name: Rename Binary Files
         uses: botpress/gh-actions/rename_binaries@master
 
@@ -55,4 +72,4 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          aws s3 sync bin s3://botpress-dev-bins/studio/${{ steps.info.outputs.branch_sanitized }}
+          aws s3 sync bin s3://botpress-dev-bins/studio/${GITHUB_HEAD_REF}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Debug
         run: |
           echo if this action succeeds a binary will be available at
+          echo head branch is ${{ env.GITHUB_HEAD_REF }}
           echo s3://botpress-dev-bins/studio/${{ steps.info.outputs.branch_sanitized }}
 
       - name: Checkout Code


### PR DESCRIPTION
Alright, this is my take on improving the prerelease GH task.

If you toggle between "draft" and "ready for review" you'll see that the action gets canceled and started accordingly.

Also, you'll notice that `${GITHUB_HEAD_REF}` outputs the correct branch name instead of something like `refs_pull_120_merge`.