### PR TITLE
fix(flow): tiny z-index css fix on flow editor

### DIFF
--- a/packages/studio-ui/src/web/views/FlowBuilder/diagram/nodes/Components/style.scss
+++ b/packages/studio-ui/src/web/views/FlowBuilder/diagram/nodes/Components/style.scss
@@ -459,7 +459,6 @@
   padding: 0;
   position: relative;
   width: 135px;
-  z-index: 1;
 
   &.small {
     height: auto;


### PR DESCRIPTION
Not in my linear tasks but a tiny visual bug fix.

Before 

https://user-images.githubusercontent.com/159949/146086294-12bb7a2a-3163-4a0c-a910-bf4630176309.mov

After

https://user-images.githubusercontent.com/159949/146086303-c4b5a558-48a7-49dd-93ba-6842f0686dd9.mov


