### PR TITLE
fix(actions): hide module actions on cloud-enabled bots

### DIFF
--- a/packages/studio-be/src/sdk/botpress.d.ts
+++ b/packages/studio-be/src/sdk/botpress.d.ts
@@ -895,6 +895,7 @@ declare module 'botpress/sdk' {
       [lang: string]: string
     }
 
+    isCloudBot?: boolean
     cloud?: CloudConfig
   }
 

--- a/packages/studio-ui/src/web/views/FlowBuilder/nodeProps/ActionModalForm.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/nodeProps/ActionModalForm.tsx
@@ -304,7 +304,7 @@ class ActionModalForm extends Component<Props, State> {
 
 const mapStateToProps = (state: RootReducer) => ({
   actions: state.skills.actions?.filter(a => a.legacy),
-  isCloudBot: Boolean(state.bot?.cloud?.clientId)
+  isCloudBot: Boolean(state.bot.isCloudBot)
 })
 
 export default connect(mapStateToProps, undefined)(ActionModalForm)

--- a/packages/studio-ui/src/web/views/FlowBuilder/nodeProps/ActionModalForm.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/nodeProps/ActionModalForm.tsx
@@ -99,19 +99,19 @@ class ActionModalForm extends Component<Props, State> {
 
   prepareActions() {
     this.setState({
-      avActions: (this.props.actions || [])
-        // hide module actions on cloud-enabled bots
-        .filter(action =>
-          !this.props.isCloudBot ? true : action.name.indexOf('builtin') === 0 || action.name.indexOf('/') === -1
-        )
-        .map(x => {
-          return {
-            label: x.name,
-            value: x.name,
-            metadata: { ...x }
-          }
-        })
+      avActions: (this.props.actions || []).filter(this.isCloudSafeAction).map(x => {
+        return {
+          label: x.name,
+          value: x.name,
+          metadata: { ...x }
+        }
+      })
     })
+  }
+
+  // Only allow builtin actions and internal actions on cloud-enabled bots
+  isCloudSafeAction = (action: LocalActionDefinition) => {
+    return !this.props.isCloudBot || action.name.indexOf('builtin') === 0 || action.name.indexOf('/') === -1
   }
 
   onChangeType = (type: ActionType) => () => {

--- a/packages/studio-ui/src/web/views/FlowBuilder/nodeProps/ActionModalForm.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/nodeProps/ActionModalForm.tsx
@@ -99,13 +99,18 @@ class ActionModalForm extends Component<Props, State> {
 
   prepareActions() {
     this.setState({
-      avActions: (this.props.actions || []).map(x => {
-        return {
-          label: x.name,
-          value: x.name,
-          metadata: { ...x }
-        }
-      })
+      avActions: (this.props.actions || [])
+        // hide module actions on cloud-enabled bots
+        .filter(action =>
+          !this.props.isCloudBot ? true : action.name.indexOf('builtin') === 0 || action.name.indexOf('/') === -1
+        )
+        .map(x => {
+          return {
+            label: x.name,
+            value: x.name,
+            metadata: { ...x }
+          }
+        })
     })
   }
 
@@ -298,7 +303,8 @@ class ActionModalForm extends Component<Props, State> {
 }
 
 const mapStateToProps = (state: RootReducer) => ({
-  actions: state.skills.actions?.filter(a => a.legacy)
+  actions: state.skills.actions?.filter(a => a.legacy),
+  isCloudBot: Boolean(state.bot?.cloud?.clientId)
 })
 
 export default connect(mapStateToProps, undefined)(ActionModalForm)


### PR DESCRIPTION
Hide module actions on cloud-enabled bots because they're not supported on the cloud yet

<img width="965" alt="Screen Shot 2022-01-12 at 9 47 47 AM" src="https://user-images.githubusercontent.com/159949/149162963-ba478316-2f7d-44b0-970a-50e4d0f2a6ed.png">

