### PR TITLE
chore(ci_cd): use gh-actions v1

### DIFF
--- a/.github/workflows/branch_deleted.yml
+++ b/.github/workflows/branch_deleted.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Extract Informations
         id: info
-        uses: botpress/gh-actions/extract_info@master
+        uses: botpress/gh-actions/extract_info@v1
         with:
           branch: ${{ github.event.ref }}
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Get Release Details
         id: release_details
-        uses: botpress/gh-actions/get_release_details@master
+        uses: botpress/gh-actions/get_release_details@v1
 
       - name: Fetch Node Packages
         run: yarn
@@ -45,10 +45,10 @@ jobs:
 
       - name: Extract Informations
         id: info
-        uses: botpress/gh-actions/extract_info@master
+        uses: botpress/gh-actions/extract_info@v1
 
       - name: Rename Binary Files
-        uses: botpress/gh-actions/rename_binaries@master
+        uses: botpress/gh-actions/rename_binaries@v1
 
       - name: Publish Binaries
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           yarn
       - name: Get Release Details
         id: release_details
-        uses: botpress/gh-actions/get_release_details@master
+        uses: botpress/gh-actions/get_release_details@v1
       - name: Fix Change Log
         id: changelog
         run: |


### PR DESCRIPTION
This PR makes sure we use the v1 of our custom actions from botpress/gh-actions. This allows us to potentially push breaking changes on master without ever impacting actions that currently depend on them.

Similar to what has been done here: https://github.com/botpress/botpress/pull/11211