### PR TITLE
fix(studio): prevent skills folder with casing

### DIFF
--- a/packages/studio-ui/src/web/views/FlowBuilder/sidePanelFlows/FlowNameModal.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/sidePanelFlows/FlowNameModal.tsx
@@ -61,7 +61,7 @@ const FlowNameModal: FC<Props> = props => {
     submitText = lang.tr('rename')
   }
 
-  const isNameInvalid = name?.startsWith('skills/')
+  const isNameInvalid = name?.toLowerCase().startsWith('skills/')
 
   return (
     <Dialog isOpen={props.isOpen} onClose={closeModal} transitionDuration={0} {...dialog}>


### PR DESCRIPTION
When fixing DEV-1425, forgot to handle all possible casings for the skills folder.