### PR TITLE
fix: properly display start enterprise trial

### DIFF
--- a/packages/studio-be/src/studio/studio-router.ts
+++ b/packages/studio-be/src/studio/studio-router.ts
@@ -209,7 +209,7 @@ export class StudioRouter extends CustomRouter {
               window.WORKSPACE_ID = "${workspaceId}";
               window.IS_BOT_MOUNTED = ${this.botService.isBotMounted(botId)};
               window.SEGMENT_WRITE_KEY = "${segmentWriteKey}";
-              window.IS_PRO_ENABLED = "${process.IS_PRO_ENABLED}";
+              window.IS_PRO_ENABLED = ${process.IS_PRO_ENABLED};
             })(typeof window != 'undefined' ? window : {})
           `
 


### PR DESCRIPTION
We were sending a boolean variable as string then check the condition based on the string value not the bool value.

before
![Screen Shot 2022-01-20 at 3 05 16 PM](https://user-images.githubusercontent.com/955524/150414841-b0c8844b-8ec2-4451-be61-e1471146f606.png)

after
![Screen Shot 2022-01-20 at 3 14 00 PM](https://user-images.githubusercontent.com/955524/150414927-01d14710-f528-4c26-b92c-1030b8a1681f.png)
 