### PR TITLE
fix(studio): prevent back & forth when file is not found

### DIFF
--- a/packages/studio-be/src/core/app/server.ts
+++ b/packages/studio-be/src/core/app/server.ts
@@ -236,7 +236,12 @@ export class HTTPServer {
       )
     }
 
-    this.app.use('/assets/studio/ui', this.guardWhiteLabel(), express.static(resolveStudioAsset('')))
+    this.app.use(
+      '/assets/studio/ui',
+      this.guardWhiteLabel(),
+      express.static(resolveStudioAsset(''), { fallthrough: false })
+    )
+
     this.app.use(`${BASE_API_PATH}/studio/modules`, this.modulesRouter.router)
 
     await this.studioRouter.setupRoutes(this.app)


### PR DESCRIPTION
When a file is not found in the studio assets, it forwards the request to the core, which then re-directs it back to the studio... This happens during like 30 seconds, then it fails the request. 

The fix is simple. if the file is not found, it just stops there.

![image](https://user-images.githubusercontent.com/42552874/150827413-b838d3a4-4d3b-42d0-a686-a615a1650f09.png)
