### PR TITLE
fix(studio): fix random error with lang switcher

### DIFF
--- a/packages/studio-ui/src/web/components/Layout/StatusBar/LangSwitcher.tsx
+++ b/packages/studio-ui/src/web/components/Layout/StatusBar/LangSwitcher.tsx
@@ -55,10 +55,6 @@ class LangSwitcher extends React.Component<Props> {
     }
   }
 
-  componentWillUnmount() {
-    this.elems = null
-  }
-
   handleKeyDown = (l, e) => {
     if (e.key === 'Enter') {
       this.switchLang(l)


### PR DESCRIPTION
Fix a random error which happens sometimes with slower connections. Someone one call takes longer, and the lang switcher mounts, then unmounts, then remounts, but since it changed the value to null when unmounting, it crashed the studio.

Quick & dirty fix. Eventually we'll get rid of react-bootstrap once and for all

![image](https://user-images.githubusercontent.com/42552874/151007763-5dcd770e-3976-4bc0-9fcf-81c17c6344ef.png)
