### PR TITLE
fix(nlu): correctly display error if training fails before it starts

### DIFF
--- a/packages/studio-be/src/studio/nlu/bot/index.ts
+++ b/packages/studio-be/src/studio/nlu/bot/index.ts
@@ -56,8 +56,11 @@ export class Bot {
   }
 
   public train = async (language: string): Promise<void> => {
-    await this._botState.startTraining(language)
     try {
+      const pending = this._trainPending(language)
+      this._webSocket(pending)
+
+      await this._botState.startTraining(language)
       await poll(async () => {
         const ts = await this.syncAndGetState(language)
         this._webSocket(ts)
@@ -125,6 +128,13 @@ export class Bot {
 
   private _needsTraining = (language: string): BpTraining => ({
     status: 'needs-training',
+    progress: 0,
+    language,
+    botId: this._botId
+  })
+
+  private _trainPending = (language: string): BpTraining => ({
+    status: 'training-pending',
     progress: 0,
     language,
     botId: this._botId


### PR DESCRIPTION
If you try training a chatbot that has an intent with no utterances, it crashes the studio.

This regression was introduced by me here: https://github.com/botpress/studio/pull/255

This PR fixes it, and make sure the error is displayed in the UI