### PR TITLE
fix(studio): add the nat ext path

### DIFF
--- a/packages/studio-be/src/sdk/rewire.ts
+++ b/packages/studio-be/src/sdk/rewire.ts
@@ -8,7 +8,9 @@ const originalRequire = Module.prototype.require
 const platformFolders: string[] = []
 const nativeBindingsPaths: string[] = []
 
-const nativeExBaseFolder = syspath.resolve(require.resolve('@botpress/native-extensions'), '../../bin')
+const nativeExBaseFolder =
+  (process.core_env.NATIVE_EXTENSIONS_DIR && syspath.resolve(process.env.NATIVE_EXTENSIONS_DIR!)) ||
+  syspath.resolve(require.resolve('@botpress/native-extensions'), '../../bin')
 
 if (process.distro.os === 'linux') {
   platformFolders.push('linux/default')


### PR DESCRIPTION
On the server, you can override the native extensions path to provide os-specific bindings, but it's not present on the studio. this change will cause no issue with existing installations, but will bring back the previous support for os we don't support out of the box.