### PR TITLE
fix(builtin): add missing template name

### DIFF
--- a/packages/studio-be/src/builtin/bot-templates/learn-botpress/bot.config.json
+++ b/packages/studio-be/src/builtin/bot-templates/learn-botpress/bot.config.json
@@ -5,6 +5,7 @@
   "version": "12.26.3",
   "author": "Botpress, Inc.",
   "license": "AGPL-3.0",
+  "name": "Learn Botpress",
   "imports": {
     "modules": [],
     "incomingMiddleware": [],


### PR DESCRIPTION
Well this is pretty self explanatory.

Before
<img width="490" alt="Screen Shot 2022-01-25 at 2 11 25 PM" src="https://user-images.githubusercontent.com/955524/152034425-4c799ddd-2bb5-41a8-a448-e666dc48146b.png">


After: 
<img width="492" alt="Screen Shot 2022-02-01 at 2 08 08 PM" src="https://user-images.githubusercontent.com/955524/152034436-68fa2ad5-e19b-4455-a1bb-5e94afaea168.png">


closes : BUS-195