### PR TITLE
fix(translation): fix contentTypes translation references

### DIFF
--- a/packages/studio-ui/src/web/components/ContentForm/UploadWidget/UrlUpload.tsx
+++ b/packages/studio-ui/src/web/components/ContentForm/UploadWidget/UrlUpload.tsx
@@ -51,7 +51,7 @@ const UrlUpload: FC<IUrlUploadProps> = props => {
 
       {value && !isUrlOrRelativePath(value) && (
         <div className={localStyle.expressionWrapper}>
-          {lang.tr('module.builtin.types.infoInterpreted')} <span className={localStyle.italic}>{value}</span>
+          {lang.tr('contentTypes.infoInterpreted')} <span className={localStyle.italic}>{value}</span>
           <div className={localStyle.expressionWrapperActions}>
             <Tooltip content={lang.tr('delete')} position={Position.TOP}>
               <Button minimal small intent={Intent.DANGER} icon="trash" onClick={onDelete}></Button>

--- a/packages/studio-ui/src/web/components/ContentForm/UploadWidget/index.tsx
+++ b/packages/studio-ui/src/web/components/ContentForm/UploadWidget/index.tsx
@@ -64,7 +64,7 @@ const UploadWidget: FC<IUploadWidgetProps> = props => {
     <AccessControl
       operation="write"
       resource="bot.media"
-      fallback={<em>{lang.tr('module.builtin.types.permissionDenied')}</em>}
+      fallback={<em>{lang.tr('contentTypes.permissionDenied')}</em>}
     >
       <Fragment>
         {!enterUrlManually && (
@@ -84,9 +84,7 @@ const UploadWidget: FC<IUploadWidgetProps> = props => {
         {!value && (
           <div className={localStyle.fieldContainer}>
             <a className={localStyle.toggleLink} onClick={handleToggleManually}>
-              {!enterUrlManually
-                ? lang.tr('module.builtin.types.enterUrlChoice')
-                : lang.tr('module.builtin.types.uploadFileChoice')}
+              {!enterUrlManually ? lang.tr('contentTypes.enterUrlChoice') : lang.tr('contentTypes.uploadFileChoice')}
             </a>
 
             {error && <p className={cn(style.fieldError, localStyle.fieldError)}>{error}</p>}


### PR DESCRIPTION
The references to the content types translation module were wrong. I used the right ones.

![95bf279b-ba07-43f1-b454-d525f72a65b9](https://user-images.githubusercontent.com/10071388/152193668-5fa7966d-8a69-4cac-9b10-5ca9fa0cb1e0.png)
![image](https://user-images.githubusercontent.com/10071388/152193278-effbc638-1ccb-471f-8fe3-b87fe5c87304.png)
