### PR TITLE
fix(studio): fix auto token refresh

### DIFF
--- a/packages/studio-ui/src/web/components/App/index.tsx
+++ b/packages/studio-ui/src/web/components/App/index.tsx
@@ -69,7 +69,6 @@ class App extends Component<Props> {
     this.fetchData()
 
     authEvents.on('login', this.fetchData)
-    authEvents.on('new_token', this.fetchData)
 
     EventBus.default.on('flow.changes', payload => {
       // TODO: should check if real uniq Id is different. Multiple browser windows can be using the same email. There should be a uniq window Id.

--- a/packages/studio-ui/src/web/components/App/index.tsx
+++ b/packages/studio-ui/src/web/components/App/index.tsx
@@ -100,7 +100,10 @@ class App extends Component<Props> {
     return (
       <Fragment>
         {!window.IS_STANDALONE && (
-          <TokenRefresher getAxiosClient={() => axios} onRefreshCompleted={token => setToken(token)} />
+          <TokenRefresher
+            getAxiosClient={() => axios.create({ baseURL: '/api/v1' })}
+            onRefreshCompleted={token => setToken(token)}
+          />
         )}
         <Routes />
       </Fragment>

--- a/packages/studio-ui/src/web/util/Auth.ts
+++ b/packages/studio-ui/src/web/util/Auth.ts
@@ -8,7 +8,11 @@ export const authEvents = new EventEmitter2()
 export const setToken = (token: any): void => {
   auth.setToken(token)
 
-  axios.defaults.headers.common[CSRF_TOKEN_HEADER] = token.csrf
-  axios.defaults.headers.common['Authorization'] = `Bearer ${token}`
+  if (window['USE_JWT_COOKIES']) {
+    axios.defaults.headers.common[CSRF_TOKEN_HEADER] = token.csrf
+  } else {
+    axios.defaults.headers.common['Authorization'] = `Bearer ${token.jwt || token}`
+  }
+
   authEvents.emit('new_token')
 }


### PR DESCRIPTION
By default, the user's token on the studio is supposed to be refreshed automatically (as long as the studio is opened, the token will refresh itself instead of logging out the user).

The problem was that the refresh endpoint was not correct, it replied html instead of the token... Now it will automatically refresh the token, so we'll stop getting disconnected from the studio.

