### PR TITLE
revert(deps): downgrade fs-extra to v9

### DIFF
--- a/packages/studio-be/package.json
+++ b/packages/studio-be/package.json
@@ -31,7 +31,7 @@
     "express": "^4.17.2",
     "express-rate-limit": "^3.5.1",
     "express-urlrewrite": "^1.4.0",
-    "fs-extra": "^10.0.0",
+    "fs-extra": "^9.1.0",
     "getos": "^3.2.1",
     "globrex": "^0.1.2",
     "http-proxy-middleware": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1365,7 +1365,7 @@ __metadata:
     express: ^4.17.2
     express-rate-limit: ^3.5.1
     express-urlrewrite: ^1.4.0
-    fs-extra: ^10.0.0
+    fs-extra: ^9.1.0
     getos: ^3.2.1
     globrex: ^0.1.2
     http-proxy-middleware: ^2.0.2
@@ -9465,17 +9465,6 @@ __metadata:
   version: 1.0.0
   resolution: "fs-constants@npm:1.0.0"
   checksum: 18f5b718371816155849475ac36c7d0b24d39a11d91348cfcb308b4494824413e03572c403c86d3a260e049465518c4f0d5bd00f0371cdfcad6d4f30a85b350d
-  languageName: node
-  linkType: hard
-
-"fs-extra@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "fs-extra@npm:10.0.0"
-  dependencies:
-    graceful-fs: ^4.2.0
-    jsonfile: ^6.0.1
-    universalify: ^2.0.0
-  checksum: 5285a3d8f34b917cf2b66af8c231a40c1623626e9d701a20051d3337be16c6d7cac94441c8b3732d47a92a2a027886ca93c69b6a4ae6aee3c89650d2a8880c0a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR fixes an issue with the binary produced with `pkg`. Since pkg uses fs-extra v8, it conflicted, when running the binary, with the version (v10) that was installed in the `studio-be` package.

Related to: https://github.com/vercel/pkg/issues/1180

Closes BUS-214