### PR TITLE
fix(superinput): various ux bugs

### DIFF
--- a/packages/superinput/demo/app.tsx
+++ b/packages/superinput/demo/app.tsx
@@ -37,7 +37,7 @@ function App() {
         </section>
         <section>
           <h2>expression (no eventState)</h2>
-          <SuperInput type={SiTypes.EXPRESSION} value={code0} {...msgs} />
+          <SuperInput type={SiTypes.EXPRESSION} value={code0} {...msgs} placeholder="something" />
         </section>
         <section>
           <h2>Valid</h2>

--- a/packages/superinput/src/EvalPanel.tsx
+++ b/packages/superinput/src/EvalPanel.tsx
@@ -4,9 +4,7 @@ import { PanelProps } from './types'
 
 const EvalPanel = ({ valid, text }: PanelProps) => {
   return (
-    <div className={`bp-editor-panel ${valid === null ? 'no-eventState' : valid ? 'valid' : 'invalid'}`}>
-      <p>{text}</p>
-    </div>
+    <div className={`bp-editor-panel ${valid === null ? 'no-eventState' : valid ? 'valid' : 'invalid'}`}>{text}</div>
   )
 }
 

--- a/packages/superinput/src/index.scss
+++ b/packages/superinput/src/index.scss
@@ -161,12 +161,7 @@ $pt-border-radius: 3px;
   padding: 0.5rem;
   color: $black;
   border-radius: $pt-border-radius;
-
-  p {
-    margin: 0;
-    white-space: pre;
-    line-height: normal;
-  }
+  overflow-wrap: normal;
 
   &.valid {
     background: mix($success, white, 20%);


### PR DESCRIPTION
- [x] Entering first key, cursor shifts to the left.
- [x] on autofocus, cursor shows up at start of string instead of end
- [x] eval pannel's text overflows past border when too much text
