### PR TITLE
fix(build): fix package on windows & cmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clean": "yarn workspaces foreach -pi run clean",
     "start": "ts-node -T --dir scripts start_studio",
     "setup": "ts-node -T --dir scripts create_default_env --location ./.env.debug",
-    "package": "yarn clean && yarn build && ts-node -T --dir scripts package",
+    "package": "ts-node -T --dir scripts package",
     "release": "ts-node -T --dir scripts release",
     "prettier": "prettier --check './packages/**/*.ts(x)' '!**/*.d.ts'",
     "eslint": "eslint packages/ --ext .ts,.tsx",

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -10,7 +10,7 @@ const installBindings = async () => {
 
   for (const platform of platforms) {
     await execute(
-      `./node_modules/.bin/node-pre-gyp install --directory=./node_modules/sqlite3 --target_platform=${platform} --target_arch=x64`,
+      `cross-env ./node_modules/.bin/node-pre-gyp install --directory=./node_modules/sqlite3 --target_platform=${platform} --target_arch=x64`,
       undefined,
       { silent: true }
     )
@@ -27,7 +27,9 @@ const renameBinaries = async () => {
 
   for (const [oldPath, newPath] of mappings) {
     await new Promise((resolve, reject) =>
-      fs.rename(`${outputPath}/${oldPath}`, `${outputPath}/${newPath}`, err => (err ? reject(err) : resolve(undefined)))
+      fs.rename(`${outputPath}/${oldPath}`, `${outputPath}/${newPath}`, (err) =>
+        err ? reject(err) : resolve(undefined)
+      )
     )
   }
 }


### PR DESCRIPTION
Packaging failed on windows because of the command not including cross-env.

![image](https://user-images.githubusercontent.com/42552874/154395794-497ac08f-306c-4437-970e-ca95941f761a.png)


Also made a small adjustment to the package.json file, scripts should do a single task... Package shouldn't clean/build/package, it just packages. If those commands must be used together, then they must be typed independently