### PR TITLE
fix(qna): improve slot intent sidebar ui

### DIFF
--- a/packages/studio-ui/src/web/views/Nlu/intents/style.scss
+++ b/packages/studio-ui/src/web/views/Nlu/intents/style.scss
@@ -15,16 +15,19 @@
 }
 
 .header {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  gap: 10px;
   margin: 10px 0;
 
   .hint {
     color: #738694;
+    margin: 0;
+  }
 
-    &:not(.lightEditorHint) {
-      max-width: 50%;
-    }
+  @media (min-width: 1025px) {
+    grid-auto-flow: column;
+    align-items: end;
+    justify-content: space-between;
   }
 }
 
@@ -211,6 +214,7 @@ p.utterance {
   border-left: solid 1px #eee;
   flex-grow: 0.2;
   overflow: auto;
+  background-color: white;
 }
 
 .centerContainer {

--- a/packages/studio-ui/src/web/views/Nlu/intents/style.scss.d.ts
+++ b/packages/studio-ui/src/web/views/Nlu/intents/style.scss.d.ts
@@ -26,7 +26,6 @@ interface CssExports {
   'label-colors-6': string;
   'label-colors-7': string;
   'label-colors-8': string;
-  'lightEditorHint': string;
   'link': string;
   'liteIntentEditor': string;
   'selectionText': string;


### PR DESCRIPTION
Slot panel resize was fixed in #295 but this makes some minor improvements to slot panel UI on smaller screen sizes.

Before
<img width="507" alt="Screen Shot 2022-02-21 at 8 43 38 AM" src="https://user-images.githubusercontent.com/159949/154968799-1306e263-6cf6-4a5a-b313-505ebdacb778.png">

After

https://user-images.githubusercontent.com/159949/154968810-58217465-4afb-4bd7-8e90-9226b24aacde.mov


