### PR TITLE
fix(content): added translations for card buttons

### DIFF
--- a/packages/studio-be/src/builtin/content-types/card.ts
+++ b/packages/studio-be/src/builtin/content-types/card.ts
@@ -1,7 +1,6 @@
 import { ContentType } from 'botpress/sdk'
 import utils from './_utils'
-import ActionButton from './action_button'
-import Carousel from './carousel'
+import actionButtonSchema from './action_button'
 
 export const cardSchema = {
   description: 'contentTypes.card.description',
@@ -24,8 +23,8 @@ export const cardSchema = {
     },
     actions: {
       type: 'array',
-      title: 'contentTypes.actionButton',
-      items: ActionButton.jsonSchema
+      title: 'contentTypes.card.actionButtons',
+      items: actionButtonSchema
     }
   }
 }
@@ -33,7 +32,7 @@ export const cardSchema = {
 const contentType: ContentType = {
   id: 'builtin_card',
   group: 'Built-in Messages',
-  title: 'card',
+  title: 'contentTypes.card.title',
   jsonSchema: cardSchema,
   uiSchema: {},
 

--- a/packages/studio-ui/src/web/translations/en.json
+++ b/packages/studio-ui/src/web/translations/en.json
@@ -41,6 +41,8 @@
       "title": "Action Button"
     },
     "card": {
+      "title": "Card",
+      "actionButtons": "Card action buttons",
       "description": "A card message with a title with optional subtitle, image and action buttons."
     },
     "carousel": {

--- a/packages/studio-ui/src/web/translations/es.json
+++ b/packages/studio-ui/src/web/translations/es.json
@@ -41,6 +41,8 @@
       "title": "Action Button"
     },
     "card": {
+      "title": "Carta",
+      "actionButtons": "Botones de acción",
       "description": "Un mensaje de tarjeta con un título con subtítulos opcionales, imagen y botones de acción."
     },
     "carousel": {

--- a/packages/studio-ui/src/web/translations/fr.json
+++ b/packages/studio-ui/src/web/translations/fr.json
@@ -41,6 +41,8 @@
       "title": "Bouton d'action"
     },
     "card": {
+      "title": "Carte",
+      "actionButtons": "Boutons d'action de la carte",
       "description": "Une carte est un message avec un titre, sous-titre optionnel, une image et des boutons d'actions."
     },
     "carousel": {


### PR DESCRIPTION
Since the json schema is generated for each new chatbot in its content-type folder, we would need a file migration in order to get that fix for existing chatbots. If we want to go that route this needs to be addressed in another pull request. Meanwhile these little changes fixes it for newly created chatbots.
Before: 
<img width="505" alt="Screen Shot 2022-02-22 at 9 40 38 PM" src="https://user-images.githubusercontent.com/955524/155254451-82fdc958-689b-49e6-8e9e-d91d737f9b7f.png">

After
<img width="508" alt="Screen Shot 2022-02-22 at 9 37 41 PM" src="https://user-images.githubusercontent.com/955524/155254563-35ef3307-2693-46a4-9b9f-f520bdeb6855.png">
