### PR TITLE
fix(builtin): slot update context now works without need for studio

### DIFF
--- a/packages/studio-be/src/builtin/actions/basic-skills/slot_update_contexts.js
+++ b/packages/studio-be/src/builtin/actions/basic-skills/slot_update_contexts.js
@@ -1,16 +1,28 @@
-const axios = require('axios')
+/**
+ * @typedef {Object} IntentDefinition
+ * @property {string} name
+ * @property {Object[]} slots
+ * @property {string[]} contexts
+ * @property {Object} utterances
+ */
+
+/**
+ * retreives the intent definition from the ghost
+ * @hidden true
+ * @param {string} intentName The name of the intent to get contexts from
+ * @returns {Promise<IntentDefinition>} intent
+ */
+const readIntentFromGhost = (intentName) =>
+  bp.ghost.forBot(event.botId).readFileAsObject('intents', `${intentName}.json`)
 
 /**
  * Update the session nluContexts for a specific intent
  * @hidden true
- * @param intentName The name of the intent to get contexts from
+ * @param {string} intentName The name of the intent to get contexts from
  */
-const updateContexts = async intentName => {
-  const botId = event.botId
-  const axiosConfig = await bp.http.getAxiosConfigForBot(botId, { localUrl: true, studioUrl: true })
-  const { data } = await axios.get(`/nlu/intents/${intentName}`, axiosConfig)
-
-  const nluContexts = data.contexts.map(context => {
+const updateContexts = async (intentName) => {
+  const intent = await readIntentFromGhost(intentName)
+  const nluContexts = intent.contexts.map((context) => {
     return {
       context,
       ttl: 1000


### PR DESCRIPTION
This is my second attempt at fixing DEV-2361. My first attempt was [in this PR](https://github.com/botpress/studio/pull/300).

What happened is:
- The routes where moved to the studio
- So my fix was to call the new location instead of the old one
- But now that I think about it, is it impossible for an action that runs on the cloud to call the studio
- So I replaced the axios call by reading the ghost directly

I don't consider this fix "pretty" or "sexy", but it works and it's good enough