### PR TITLE
fix(server): fix loading typings when running bin version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
       "./node_modules/xml-encryption/lib/templates/*.tpl.xml",
       "./node_modules/npm/**/*",
       "./packages/studio-be/out/ui/**",
-      "./packages/studio-be/out/builtin/**"
+      "./packages/studio-be/out/builtin/**",
+      "./packages/studio-be/out/sdk/*.txt",
+      "./packages/studio-be/out/typings/*.txt"
     ],
     "targets": [
       "node12-win32-x64",


### PR DESCRIPTION
This PR fixes an issue where typings were not included in the binary version of the studio resulting in files not found error when trying to load the typings.

Closes DEV-2383