### PR TITLE
fix(studio): fix libraries

### DIFF
--- a/packages/studio-be/src/studio/libraries/libraries-router.ts
+++ b/packages/studio-be/src/studio/libraries/libraries-router.ts
@@ -43,18 +43,18 @@ export class LibrariesRouter extends CustomStudioRouter {
       })
     )
 
-    router.get(
-      '/search/:name',
+    router.post(
+      '/search',
       this.asyncMiddleware(async (req: any, res: any) => {
-        const { data } = await axios.get(`https://www.npmjs.com/search/suggestions?q=${req.params.name}`)
+        const { data } = await axios.get(`https://www.npmjs.com/search/suggestions?q=${req.body.name}`)
         res.send(data)
       })
     )
 
-    router.get(
-      '/details/:name',
+    router.post(
+      '/details',
       this.asyncMiddleware(async (req: any, res: any) => {
-        const { data } = await axios.get(`https://registry.npmjs.org/${req.params.name}`, {
+        const { data } = await axios.get(`https://registry.npmjs.org/${req.body.name}`, {
           headers: {
             accept: 'application/vnd.npm.install-v1+json'
           }

--- a/packages/studio-be/src/studio/libraries/libraries-service.ts
+++ b/packages/studio-be/src/studio/libraries/libraries-service.ts
@@ -55,7 +55,10 @@ export class LibrariesService {
       return
     }
 
-    const archivePath = await createArchive(`${nodeModules}.tgz`, nodeModules, glob.sync('**/*', { cwd: nodeModules }))
+    // @ is a special character in tar and must be prepended
+    const files = glob.sync('**/*', { cwd: nodeModules }).map((name) => (name.startsWith('@') ? `./${name}` : name))
+
+    const archivePath = await createArchive(`${nodeModules}.tgz`, nodeModules, files)
 
     if (process.BPFS_STORAGE === 'disk') {
       return

--- a/packages/studio-ui/src/web/views/Libraries/AddLibrary.tsx
+++ b/packages/studio-ui/src/web/views/Libraries/AddLibrary.tsx
@@ -34,7 +34,7 @@ const AddLibrary = (props) => {
   const searchChanged = async (query, event) => {
     if (event) {
       try {
-        const { data } = await axios.get(`${window.STUDIO_API_PATH}/libraries/search/${query}`)
+        const { data } = await axios.post(`${window.STUDIO_API_PATH}/libraries/search`, { name: query })
 
         setItems(data)
         setRepoName('')


### PR DESCRIPTION
This fixes two issues with the libraries on the studio:
1. Adding a lib would crash the studio (happened with packages starting with an @)
2. Search wasn't working with packages including a slash

![image](https://user-images.githubusercontent.com/42552874/156453814-5cace9e3-8c09-44e9-b0f7-f79cf48d8a93.png)
