### PR TITLE
chore(studio-be): add route to invalidate cms cache for bot

### DIFF
--- a/packages/studio-be/src/studio/internal-router.ts
+++ b/packages/studio-be/src/studio/internal-router.ts
@@ -83,5 +83,19 @@ export class InternalRouter extends CustomStudioRouter {
         res.sendStatus(200)
       })
     )
+
+    router.post(
+      '/invalidateCmsForBot',
+      this.asyncMiddleware(async (req, res) => {
+        const { botId } = req.body
+
+        // Invalidations are sent via redis when cluster is on
+        if (!process.CLUSTER_ENABLED) {
+          await this.cmsService.broadcastInvalidateForBot(botId)
+        }
+
+        res.sendStatus(200)
+      })
+    )
   }
 }


### PR DESCRIPTION
This PR adds a route that allows Botpess to invalidate the Studio's CMS cache for a given bot ID.

Related PR: https://github.com/botpress/botpress/pull/11631