### PR TITLE
fix(code-editor): slight adjustment

### DIFF
--- a/packages/studio-ui/src/web/views/CodeEditor/components/NewFileModal.tsx
+++ b/packages/studio-ui/src/web/views/CodeEditor/components/NewFileModal.tsx
@@ -33,9 +33,9 @@ const NewFileModal: FC<Props> = (props) => {
   const submit = async (e) => {
     e.preventDefault()
 
-    const isJs = name.endsWith('.js')
-    const isJson = name.endsWith('.json')
-    const finalName = isJs || isJson ? name : `${name}.js`
+    const finalName = name.endsWith('.js') || name.endsWith('.json') ? name : `${name}.js`
+    const isJs = finalName.endsWith('.js')
+    const isJson = finalName.endsWith('.json')
 
     let content = ' '
     if (props.selectedType === 'action_legacy' && isJs) {


### PR DESCRIPTION
Slight change I had to do, if you created a file without adding .js in the modal, it would not add the template. Logic is identical from the module