### PR TITLE
fix(hooks): send events to core on bot mount and unmount

### DIFF
--- a/packages/studio-be/src/core/app/core-client.ts
+++ b/packages/studio-be/src/core/app/core-client.ts
@@ -22,6 +22,12 @@ export const coreActions = {
   notifyFlowChanges: async (payload) => {
     await coreClient?.post('/notifyFlowChange', payload)
   },
+  unmountBot: async (botId: string) => {
+    await coreClient?.post('/unmountBot', { botId })
+  },
+  mountBot: async (botId: string) => {
+    await coreClient?.post('/mountBot', { botId })
+  },
   invalidateCmsForBot: async (botId: string) => {
     await coreClient?.post('/invalidateCmsForBot', { botId })
   },

--- a/packages/studio-be/src/core/bots/bot-service.ts
+++ b/packages/studio-be/src/core/bots/bot-service.ts
@@ -145,12 +145,19 @@ export class BotService {
     await this.configProvider.setBotConfig(botId, newConfig)
 
     if (!updatedBot.disabled) {
-      if (this.isBotMounted(botId)) {
+      const isBotMounted = this.isBotMounted(botId)
+      if (isBotMounted) {
         // we need to remount the bot to update the config
         await this.unmountBot(botId)
       }
 
       await this.mountBot(botId)
+
+      // Only send a mount bot request to the core
+      // if the bot was unmounted
+      if (!isBotMounted) {
+        await coreActions.mountBot(botId)
+      }
     }
 
     if (actualBot.defaultLanguage !== updatedBot.defaultLanguage) {
@@ -164,6 +171,7 @@ export class BotService {
 
     if (!actualBot.disabled && updatedBot.disabled) {
       await this.unmountBot(botId)
+      await coreActions.unmountBot(botId)
     }
   }
 


### PR DESCRIPTION
This PR fixes an issue where unmounting or mounting a bot using the bot config page would not trigger `after_bot_mount` and `after_bot_unmount` hooks. The reason was that the core was never aware of this change. To fix the issue, we simply send an internal call to the core telling it to unmount/mount a certain bot.

Closes https://github.com/botpress/botpress/issues/11601

Related to: 