### PR TITLE
feat(studio): add download modelweights step before uploading chatbot to cloud

### DIFF
--- a/packages/studio-be/package.json
+++ b/packages/studio-be/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.9",
     "@botpress/native-extensions": "*",
-    "@botpress/nlu-client": "1.0.0-rc.2",
+    "@botpress/nlu-client": "1.0.2-rc.6",
     "axios": "^0.25.0",
     "bluebird": "^3.7.2",
     "bluebird-global": "^1.0.1",

--- a/packages/studio-be/src/core/bots/bot-service.ts
+++ b/packages/studio-be/src/core/bots/bot-service.ts
@@ -219,15 +219,17 @@ export class BotService {
     }
   }
 
-  async exportBot(botId: string): Promise<Buffer> {
+  async exportBot(botId: string, { cloud }: { cloud: boolean } = { cloud: false }): Promise<Buffer> {
     const replaceContent: ReplaceContent = {
       from: [new RegExp(`/bots/${botId}/`, 'g')],
       to: [BOT_ID_PLACEHOLDER]
     }
+    const excludes = ['libraries/node_modules/**/*']
+    if (!cloud) {
+      excludes.push('models/**/*')
+    }
 
-    return this.ghostService
-      .forBot(botId)
-      .exportToArchiveBuffer(['models/**/*', 'libraries/node_modules/**/*'], replaceContent)
+    return this.ghostService.forBot(botId).exportToArchiveBuffer(excludes, replaceContent)
   }
 
   async duplicateBot(sourceBotId: string, destBotId: string, overwriteDest: boolean = false) {

--- a/packages/studio-be/src/studio/cloud/cloud-router.ts
+++ b/packages/studio-be/src/studio/cloud/cloud-router.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 import { CloudConfig } from 'botpress/sdk'
-import FormData from 'form-data'
+import FormData from 'form-data'q
 import qs from 'querystring'
 import { StudioServices } from 'studio/studio-router'
 import { CustomStudioRouter } from 'studio/utils/custom-studio-router'
@@ -94,7 +94,9 @@ export class CloudRouter extends CustomStudioRouter {
           return res.status(404)
         }
 
-        const botBlob = await this.botService.exportBot(botId)
+        await this.nluService.downloadAndSaveModelWeights(botId)
+
+        const botBlob = await this.botService.exportBot(botId, { cloud: true })
 
         const botMultipart = new FormData()
         botMultipart.append('botId', introspect.botId)

--- a/packages/studio-be/src/studio/cloud/cloud-router.ts
+++ b/packages/studio-be/src/studio/cloud/cloud-router.ts
@@ -1,6 +1,6 @@
 import axios from 'axios'
 import { CloudConfig } from 'botpress/sdk'
-import FormData from 'form-data'q
+import FormData from 'form-data'
 import qs from 'querystring'
 import { StudioServices } from 'studio/studio-router'
 import { CustomStudioRouter } from 'studio/utils/custom-studio-router'

--- a/packages/studio-be/src/studio/nlu/bot/index.ts
+++ b/packages/studio-be/src/studio/nlu/bot/index.ts
@@ -23,7 +23,7 @@ export class Bot {
   constructor(
     botDef: BotDefinition,
     _configResolver: ConfigResolver,
-    _nluClient: NLUClient,
+    private _nluClient: NLUClient,
     private _defRepo: DefinitionsRepository,
     _models: ModelEntryService,
     _trainings: TrainingEntryService,
@@ -74,6 +74,10 @@ export class Bot {
       const needsTraining = this._needsTraining(language)
       this._webSocket({ ...needsTraining, error: { message: err.message, type: 'internal' } })
     }
+  }
+
+  public async downloadModelWeights(appId: string, modelId: string) {
+    return this._nluClient.downloadModelWeights(appId, modelId)
   }
 
   public syncAndGetState = async (language: string): Promise<BpTraining> => {

--- a/packages/studio-be/src/studio/nlu/bot/index.ts
+++ b/packages/studio-be/src/studio/nlu/bot/index.ts
@@ -76,7 +76,7 @@ export class Bot {
     }
   }
 
-  public async downloadModelWeights(appId: string, modelId: string) {
+  public async downloadModelWeights(appId: string, modelId: string): Promise<Buffer> {
     return this._nluClient.downloadModelWeights(appId, modelId)
   }
 

--- a/packages/studio-be/src/studio/nlu/nlu-client/cloud/client.ts
+++ b/packages/studio-be/src/studio/nlu/nlu-client/cloud/client.ts
@@ -40,6 +40,12 @@ export class CloudClient extends StanClient {
 
     this.axios.interceptors.request.use(this._requestInterceptor(tokenCache).bind(this) as any)
     this.axios.interceptors.response.use(undefined, this._errorInterceptor(this.axios as any, tokenCache).bind(this))
+
+    this.modelWeights.axios.interceptors.request.use(this._requestInterceptor(tokenCache).bind(this) as any)
+    this.modelWeights.axios.interceptors.response.use(
+      undefined,
+      this._errorInterceptor(this.axios as any, tokenCache).bind(this)
+    )
   }
 
   private _createOauthTokenClient =

--- a/packages/studio-be/src/studio/nlu/nlu-client/index.ts
+++ b/packages/studio-be/src/studio/nlu/nlu-client/index.ts
@@ -77,6 +77,15 @@ export class NLUClient {
     }
   }
 
+  public async downloadModelWeights(appId: string, modelId: string): Promise<Buffer> {
+    const downloadRes = await this._client.modelWeights.download(appId, modelId, { responseType: 'arraybuffer' })
+    if (downloadRes.status !== 'OK') {
+      throw new Error(`Download weights received status ${downloadRes.status}`)
+    }
+
+    return downloadRes.weights
+  }
+
   private _throwError(err: string | NLUError): never {
     const prefix = 'An error occured in NLU server'
     if (_.isString(err)) {

--- a/packages/studio-be/src/studio/nlu/nlu-service.ts
+++ b/packages/studio-be/src/studio/nlu/nlu-service.ts
@@ -163,6 +163,29 @@ export class NLUService {
     void bot.train(language)
   }
 
+  public async downloadAndSaveModelWeights(botId: string) {
+    const bot = this._bots[botId]
+    if (!bot) {
+      throw new BotNotMountedError(botId)
+    }
+
+    const botConfig = await this.configProvider.getBotConfig(botId)
+
+    if (!botConfig.nluModels) {
+      throw new Error('Missing NLU models. Bot is not trained.')
+    }
+
+    const modelsFolder = 'models'
+    await this.ghost.forBot(botId).deleteFolder(modelsFolder)
+
+    for (const lang of Object.keys(botConfig.nluModels)) {
+      const modelId = botConfig.nluModels[lang]
+      const modelWeights = await bot.downloadModelWeights(botId, modelId)
+
+      await this.ghost.forBot(botId).upsertFile(modelsFolder, `${modelId}.model`, modelWeights)
+    }
+  }
+
   private _getWebsocket = () => {
     return async (ts: BpTraining) => {
       const ev: NLUProgressEvent = { type: 'nlu', ...ts }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2735,14 +2735,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@botpress/nlu-client@npm:1.0.0-rc.2":
-  version: 1.0.0-rc.2
-  resolution: "@botpress/nlu-client@npm:1.0.0-rc.2"
+"@botpress/nlu-client@npm:1.0.2-rc.6":
+  version: 1.0.2-rc.6
+  resolution: "@botpress/nlu-client@npm:1.0.2-rc.6"
   dependencies:
     axios: ^0.21.1
     joi: ^17.2.2
     lodash: ^4.17.19
-  checksum: 7db1b910f79f65670f97f0ff3dc8dfdc73fd60a36cef46e72f4983b30ba4f22ec356cdd5a0433e41625af0e48d76d63aca0f9387a0c42452ebe39894c35bcbbd
+  checksum: 1505556b5d358f793a8dfa480434b9d97f936150b4f0a8e2c8b52a91d133c6164a76cf13029a271db238acc46fbf6bf5b87d01a93b9e432cdbf85b71ee9da555
   languageName: node
   linkType: hard
 
@@ -2752,7 +2752,7 @@ __metadata:
   dependencies:
     "@apidevtools/json-schema-ref-parser": ^9.0.9
     "@botpress/native-extensions": "*"
-    "@botpress/nlu-client": 1.0.0-rc.2
+    "@botpress/nlu-client": 1.0.2-rc.6
     "@types/bluebird-global": ^3.5.13
     "@types/bluebird-retry": ^0.11.5
     "@types/express": ^4.17.13


### PR DESCRIPTION
This PR adds the prerequisites steps to make sure that the models are uploaded with the chatbot when deploying to the cloud.

### To test this feature, you have two options:

1. Use the cloud NLU
    - No configuration is required
    - It will succeed and you will be able to see the model(s) on the disk under `data/<botId>/models/<modelId>`
3. Run the NLU locally 
    - Clone the NLU repository and checkout the `cloud` branch
    - Set `CLOUD_NLU_ENDPOINT` to `http://localhost3200` on Botpress side
    - Create a configuration file for the NLU server by running `yarn start init`
    - Edit the `nlu.config.json` file by adding the config `"modelTransferEnabled": true`
    - Start the NLU server and try to deploy a bot. It will fail but you will be able to see the model(s) on the disk under `data/<botId>/models/<modelId>`