### PR TITLE
fix(debugger): do not escape user input in debugger logs

### DIFF
--- a/packages/studio-ui/src/web/components/Layout/BottomPanel/Logs/index.tsx
+++ b/packages/studio-ui/src/web/components/Layout/BottomPanel/Logs/index.tsx
@@ -21,6 +21,9 @@ import logStyle from './style.scss'
 const INITIAL_LOGS_LIMIT = 200
 const MAX_LOGS_LIMIT = 500
 
+const isGlobalLog = (scope: string) => 'logs::*' === scope
+const isCurrentBotLog = (scope: string) => `logs::${window.BOT_ID}` === scope
+
 interface Props {
   toggleBottomPanel: () => void
   emulatorOpen: boolean
@@ -42,13 +45,20 @@ interface LogEntry {
   ts: Date
 }
 
+interface APILog {
+  message: string
+  level: string
+  timestamp: string
+  metadata: any
+}
+
 class BottomPanel extends React.Component<Props, State> {
   private messageListRef = React.createRef<HTMLUListElement>()
-  private debounceRefreshLogs
+  private debounceRefreshLogs: typeof this.forceUpdate
   private logs: LogEntry[]
   private debugRef = React.createRef<any>()
 
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.logs = []
     this.debounceRefreshLogs = _.debounce(this.forceUpdate, 50, { maxWait: 300 })
@@ -61,10 +71,8 @@ class BottomPanel extends React.Component<Props, State> {
   }
 
   setupListener = () => {
-    const isGlobalOrCurrentBotLog = (scope: string) => [`logs::${window.BOT_ID}`, 'logs::*'].includes(scope)
-
     EventBus.default.onAny((name, { level, message, args }) => {
-      if (!name || typeof name !== 'string' || !isGlobalOrCurrentBotLog(name)) {
+      if (!name || typeof name !== 'string' || !(isGlobalLog(name) || isCurrentBotLog(name))) {
         return
       }
 
@@ -90,7 +98,7 @@ class BottomPanel extends React.Component<Props, State> {
   }
 
   queryLogs = async () => {
-    const { data } = await axios.get(`${window.API_PATH}/admin/logs/bots/${window.BOT_ID}`, {
+    const { data } = await axios.get<APILog[]>(`${window.API_PATH}/admin/logs/bots/${window.BOT_ID}`, {
       params: {
         limit: INITIAL_LOGS_LIMIT
       }
@@ -107,14 +115,27 @@ class BottomPanel extends React.Component<Props, State> {
     })
   }
 
+  renderLogContent(content: string) {
+    const isHTML = (str: string) => {
+      const doc = new DOMParser().parseFromString(str, 'text/html')
+      return Array.from(doc.body.childNodes).some((node) => node.nodeType === 1)
+    }
+
+    if (isHTML(content)) {
+      return <span className={logStyle.message} dangerouslySetInnerHTML={{ __html: content }} />
+    } else {
+      return <span className={logStyle.message}>{content}</span>
+    }
+  }
+
   renderEntry(log: LogEntry): JSX.Element {
     const time = moment(new Date(log.ts)).format('YYYY-MM-DD HH:mm:ss')
     return (
       <li className={cn(logStyle.entry, logStyle[`level-${log.level}`])} key={`log-entry-${log.id}`}>
         <span className={logStyle.time}>{time}</span>
         <span className={logStyle.level}>{log.level}</span>
-        <span className={logStyle.message} dangerouslySetInnerHTML={{ __html: log.message }} />
-        <span className={logStyle.message} dangerouslySetInnerHTML={{ __html: log.args || '' }} />
+        {this.renderLogContent(log.message)}
+        {this.renderLogContent(log.args)}
       </li>
     )
   }


### PR DESCRIPTION
This PR adds the logic to handle displaying raw user data when possible. 

The thumb rule is basic, don't escape characters that aren't escaped by the channel-web or the console.

**Before**

![Screenshot from 2022-03-30 18-26-22](https://user-images.githubusercontent.com/9640576/160941525-fbd04495-d157-41ff-b7dd-8bbe988c91c6.png)

**After**

 
![Screenshot from 2022-03-30 18-25-28](https://user-images.githubusercontent.com/9640576/160941549-629b7a1a-5142-46bd-8e44-fc9be4788fa9.png)

Closes https://github.com/botpress/botpress/issues/11271