### PR TITLE
fix(code-editor): allow creating hooks with hook type as name

### DIFF
--- a/packages/studio-be/src/common/code-editor.ts
+++ b/packages/studio-be/src/common/code-editor.ts
@@ -115,7 +115,7 @@ export const FileTypes: { [type: string]: FileDefinition } = {
       baseDir: '/hooks',
       dirListingAddFields: (filepath: string) => ({ hookType: filepath.substr(0, filepath.indexOf('/')) }),
       upsertLocation: (file: EditableFile) => `/hooks/${file.hookType}`,
-      upsertFilename: (file: EditableFile) => file.location.replace(file.hookType!, ''),
+      upsertFilename: (file: EditableFile) => file.location.replace(`${file.hookType!}/`, ''),
       shouldSyncToDisk: true
     },
     validate: async (file: EditableFile, isWriting?: boolean) => {
@@ -141,7 +141,7 @@ export const FileTypes: { [type: string]: FileDefinition } = {
       baseDir: '/libraries',
       shouldSyncToDisk: true
     },
-    canDelete: (file) => {
+    canDelete: file => {
       return !['package.json', 'package-lock.json'].includes(file.name)
     }
   },


### PR DESCRIPTION
This PR adds the possibility to create a hook with the name of the hook type. Before this change, the resulting filename would be .js since we were removing the hook type from its name (not sure why as there seems to be no impact of doing so).

e.g. Creating an after_incoming_middleware hook named: after_incoming_middleware.js

Same changes as this PR: https://github.com/botpress/botpress/pull/11698