### PR TITLE
fix(studio): fix bot export

### DIFF
--- a/packages/studio-be/src/core/bpfs/drivers/disk-driver.ts
+++ b/packages/studio-be/src/core/bpfs/drivers/disk-driver.ts
@@ -137,7 +137,8 @@ export class DiskStorageDriver implements StorageDriver {
     const ghostIgnorePatterns = await this._getGhostIgnorePatterns(this.resolvePath('data/.ghostignore'))
     const globOptions: glob.IOptions = {
       cwd: this.resolvePath(folder),
-      dot: options.includeDotFiles
+      dot: options.includeDotFiles,
+      nodir: true
     }
 
     // options.excludes can either be a string or an array of strings or undefined


### PR DESCRIPTION
Directory listing should only return files, but for some reason, it returns the ".git" folder as a file, which fails when creating an archive