### PR TITLE
fix(qna): infinite scroll

### DIFF
--- a/packages/studio-ui/src/web/views/Qna/index.tsx
+++ b/packages/studio-ui/src/web/views/Qna/index.tsx
@@ -239,7 +239,7 @@ const QnAList: FC<Props> = (props) => {
   )
 
   return (
-    <MainLayout.Wrapper childRef={(ref) => (wrapperRef.current = ref)}>
+    <MainLayout.Wrapper>
       <MainLayout.Toolbar
         className={style.header}
         tabChange={setCurrentTab}
@@ -247,7 +247,7 @@ const QnAList: FC<Props> = (props) => {
         buttons={buttons}
         rightContent={toolBarRightContent}
       />
-      <div className={cx(style.content, { [style.empty]: !items.length && !highlighted })}>
+      <div ref={wrapperRef} className={cx(style.content, { [style.empty]: !items.length && !highlighted })}>
         {highlighted && (
           <div className={style.highlightedQna}>
             <QnA


### PR DESCRIPTION
This little change fixes the infinite scroll which was broken for bots having more than 50 qnas.

closes DEV-2625
closes https://github.com/botpress/studio/issues/348