### PR TITLE
chore(ui): add support for all iso language code

### DIFF
--- a/packages/ui-shared/package.json
+++ b/packages/ui-shared/package.json
@@ -50,6 +50,7 @@
   ],
   "dependencies": {
     "@botpress/studio-be": "*",
+    "@cospired/i18n-iso-languages": "^4.0.0",
     "axios": "^0.25.0",
     "js-cookie": "^2.2.1",
     "moment": "^2.29.1",

--- a/packages/ui-shared/src/translations/en.json
+++ b/packages/ui-shared/src/translations/en.json
@@ -92,60 +92,6 @@
   "importJson": "Import JSON",
   "insert": "Insert",
   "intent": "intent",
-  "isoLangs": {
-    "ar": {
-      "name": "Arabic",
-      "nativeName": "العربية"
-    },
-    "nl": {
-      "name": "Dutch",
-      "nativeName": "Nederlands, Vlaams"
-    },
-    "en": {
-      "name": "English",
-      "nativeName": "English"
-    },
-    "fr": {
-      "name": "French",
-      "nativeName": "Français"
-    },
-    "de": {
-      "name": "German",
-      "nativeName": "Deutsch"
-    },
-    "he": {
-      "name": "Hebrew",
-      "nativeName": "עברית"
-    },
-    "it": {
-      "name": "Italian",
-      "nativeName": "Italiano"
-    },
-    "ja": {
-      "name": "Japanese",
-      "nativeName": "日本語 (にほんご／にっぽんご)"
-    },
-    "pl": {
-      "name": "Polish",
-      "nativeName": "polski"
-    },
-    "pt": {
-      "name": "Portuguese",
-      "nativeName": "Português"
-    },
-    "ru": {
-      "name": "Russian",
-      "nativeName": "русский язык"
-    },
-    "es": {
-      "name": "Spanish",
-      "nativeName": "español"
-    },
-    "zh": {
-      "name": "Chinese",
-      "nativeName": "中文"
-    }
-  },
   "label": "Label",
   "language": "Language",
   "learnMore": "Learn more",

--- a/packages/ui-shared/src/translations/es.json
+++ b/packages/ui-shared/src/translations/es.json
@@ -92,60 +92,6 @@
   "importJson": "Importar JSON",
   "insert": "Insertar",
   "intent": "intent",
-  "isoLangs": {
-    "ar": {
-      "name": "Árabe",
-      "nativeName": "العربية"
-    },
-    "nl": {
-      "name": "Holandés",
-      "nativeName": "Nederlands, Vlaams"
-    },
-    "en": {
-      "name": "Inglés",
-      "nativeName": "English"
-    },
-    "fr": {
-      "name": "Francés",
-      "nativeName": "Français"
-    },
-    "de": {
-      "name": "Alemán",
-      "nativeName": "Deutsch"
-    },
-    "he": {
-      "name": "Hebreo",
-      "nativeName": "עברית"
-    },
-    "it": {
-      "name": "Italiano",
-      "nativeName": "Italiano"
-    },
-    "ja": {
-      "name": "Japonés",
-      "nativeName": "日本語 (にほんご／にっぽんご)"
-    },
-    "pl": {
-      "name": "Polaco",
-      "nativeName": "polski"
-    },
-    "pt": {
-      "name": "Portugués",
-      "nativeName": "Português"
-    },
-    "ru": {
-      "name": "Ruso",
-      "nativeName": "русский язык"
-    },
-    "es": {
-      "name": "Español",
-      "nativeName": "Español"
-    },
-    "zh": {
-      "name": "Chino",
-      "nativeName": "中文"
-    }
-  },
   "label": "Etiqueta",
   "language": "Language",
   "learnMore": "Aprende más",

--- a/packages/ui-shared/src/translations/fr.json
+++ b/packages/ui-shared/src/translations/fr.json
@@ -92,60 +92,6 @@
   "importJson": "Importer JSON",
   "insert": "Insérer",
   "intent": "intention",
-  "isoLangs": {
-    "ar": {
-      "name": "Arabe",
-      "nativeName": "العربية"
-    },
-    "nl": {
-      "name": "Néerlandaise",
-      "nativeName": "Nederlands, Vlaams"
-    },
-    "en": {
-      "name": "Anglaise",
-      "nativeName": "English"
-    },
-    "fr": {
-      "name": "Français",
-      "nativeName": "Français"
-    },
-    "de": {
-      "name": "Allemande",
-      "nativeName": "Deutsch"
-    },
-    "he": {
-      "name": "Hébreue",
-      "nativeName": "עברית"
-    },
-    "it": {
-      "name": "Italienne",
-      "nativeName": "Italiano"
-    },
-    "ja": {
-      "name": "Japonaise",
-      "nativeName": "日本語 (にほんご／にっぽんご)"
-    },
-    "pl": {
-      "name": "Polonais",
-      "nativeName": "polski"
-    },
-    "pt": {
-      "name": "Portugais",
-      "nativeName": "Português"
-    },
-    "ru": {
-      "name": "Russe",
-      "nativeName": "русский язык"
-    },
-    "es": {
-      "name": "Espagnole",
-      "nativeName": "español"
-    },
-    "zh": {
-      "name": "Chinois",
-      "nativeName": "中文"
-    }
-  },
   "label": "Étiquette",
   "language": "Langue",
   "learnMore": "Plus d'informations",

--- a/packages/ui-shared/src/translations/index.tsx
+++ b/packages/ui-shared/src/translations/index.tsx
@@ -1,6 +1,9 @@
+import ISOLanguages from '@cospired/i18n-iso-languages'
 import { MultiLangText } from 'botpress/sdk'
 import { isEmpty, merge } from 'lodash'
 import { createIntl, createIntlCache, IntlShape } from 'react-intl'
+
+const ISO_LANG_PREFIX = 'isoLangs.'
 
 import en from './en.json'
 import es from './es.json'
@@ -42,6 +45,11 @@ const langInit = () => {
 
   const messages = squash(translations[locale])
   const defaultLang = squash(translations[defaultLocale])
+
+  ISOLanguages.registerLocale(require('@cospired/i18n-iso-languages/langs/en.json'))
+  ISOLanguages.registerLocale(require('@cospired/i18n-iso-languages/langs/es.json'))
+  ISOLanguages.registerLocale(require('@cospired/i18n-iso-languages/langs/fr.json'))
+
   for (const key in defaultLang) {
     if (!messages[key]) {
       messages[key] = defaultLang[key]
@@ -87,7 +95,9 @@ const getUserLocale = () => {
   const browserLocale = code(navigator.language || navigator['userLanguage'] || '')
   const storageLocale = code(localStorage.getItem('uiLanguage') || '')
 
-  return translations[storageLocale] ? storageLocale : translations[browserLocale] ? browserLocale : defaultLocale
+  return (
+    translations[storageLocale] ? storageLocale : translations[browserLocale] ? browserLocale : defaultLocale
+  ) as string
 }
 
 /**
@@ -100,6 +110,12 @@ const lang = (id: string | MultiLangText, values?: { [variable: string]: any }):
 
   if (typeof id === 'object') {
     return id[locale] || id[defaultLocale] || ''
+  }
+
+  // pattern is isolangs.{code}
+  if (id.startsWith(ISO_LANG_PREFIX)) {
+    const code = id.substring(ISO_LANG_PREFIX.length, ISO_LANG_PREFIX.length + 2)
+    return ISOLanguages.getName(code, getUserLocale()) || ''
   }
 
   if (isDev) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1581,6 +1581,7 @@ __metadata:
     "@blueprintjs/datetime": 3.15.2
     "@blueprintjs/select": ^3.12.0
     "@botpress/studio-be": "*"
+    "@cospired/i18n-iso-languages": ^4.0.0
     "@types/react": ^16.8.19
     "@types/react-dom": ^16.8.4
     axios: ^0.25.0
@@ -1618,6 +1619,13 @@ __metadata:
     webpack-node-externals: ^1.7.2
   languageName: unknown
   linkType: soft
+
+"@cospired/i18n-iso-languages@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@cospired/i18n-iso-languages@npm:4.0.0"
+  checksum: 7799a4c21fb5f49633e6c83758abad3594dfbd390bb87f0b9b141c768ea5e1129c9eaa8a31fcc489a5fe81f45dd5e664e45a182406101d9b9a36d11123ad5ae2
+  languageName: node
+  linkType: hard
 
 "@cspotcode/source-map-consumer@npm:0.8.0":
   version: 0.8.0


### PR DESCRIPTION
I simply use a library instead of managing all language code manually. Notice that I "hijacked" the `tr` function so it is supported everywhere we use it without breaking the usage.

We can also make the same change in the admin code at some point

Little sign of ❤️ to @sebburon 