### PR TITLE
fix(debugger): escape html chars from logs

### DIFF
--- a/packages/studio-ui/src/web/components/Layout/BottomPanel/Logs/index.tsx
+++ b/packages/studio-ui/src/web/components/Layout/BottomPanel/Logs/index.tsx
@@ -121,8 +121,12 @@ class BottomPanel extends React.Component<Props, State> {
       return Array.from(doc.body.childNodes).some((node) => node.nodeType === 1)
     }
 
+    const escapeHtmlChars = (str: string) => {
+      return str.replace(/>/g, '&gt;').replace(/</g, '&lt;')
+    }
+
     if (isHTML(content)) {
-      return <span className={logStyle.message} dangerouslySetInnerHTML={{ __html: content }} />
+      return <span className={logStyle.message} dangerouslySetInnerHTML={{ __html: escapeHtmlChars(content) }} />
     } else {
       return <span className={logStyle.message}>{content}</span>
     }


### PR DESCRIPTION
This PR makes sure that we escape HTML chars from the logs of the debugger pane