### PR TITLE
fix(security): validate bot access

### DIFF
--- a/packages/studio-be/src/core/security/router-security.ts
+++ b/packages/studio-be/src/core/security/router-security.ts
@@ -9,6 +9,8 @@ import { AuthService, WORKSPACE_HEADER, SERVER_USER } from './auth-service'
 const debugFailure = DEBUG('audit:collab:fail')
 const debugSuccess = DEBUG('audit:collab:success')
 
+export const ALL_BOTS = '___'
+
 export const checkTokenHeader =
   (authService: AuthService, audience?: string) => async (req: RequestWithUser, res: Response, next: NextFunction) => {
     if (process.IS_STANDALONE) {
@@ -133,7 +135,8 @@ const checkPermissions =
       return new ForbiddenError(`User "${email}" doesn't have access to workspace "${req.workspace}"`)
     }
 
-    if (req.params.botId && !(await workspaceService.isBotInWorkspace(req.workspace, req.params.botId))) {
+    const isBotIdValid = req.params.botId && req.params.botId !== ALL_BOTS
+    if (isBotIdValid && !(await workspaceService.isBotInWorkspace(req.workspace, req.params.botId))) {
       return new NotFoundError(`Bot "${req.params.botId}" doesn't exist in workspace "${req.workspace}"`)
     }
 

--- a/packages/studio-be/src/core/security/router-security.ts
+++ b/packages/studio-be/src/core/security/router-security.ts
@@ -1,21 +1,13 @@
 import { checkRule, CSRF_TOKEN_HEADER_LC, JWT_COOKIE_NAME, STANDALONE_USER } from 'common/auth'
 import { RequestWithUser } from 'common/typings'
 import { ConfigProvider } from 'core/config'
-import {
-  InvalidOperationError,
-  ForbiddenError,
-  InternalServerError,
-  NotFoundError,
-  UnauthorizedError
-} from 'core/routers'
+import { InvalidOperationError, ForbiddenError, NotFoundError, UnauthorizedError } from 'core/routers'
 import { WorkspaceService } from 'core/users'
-import { NextFunction, Request, RequestHandler, Response } from 'express'
+import { NextFunction, RequestHandler, Response } from 'express'
 import { AuthService, WORKSPACE_HEADER, SERVER_USER } from './auth-service'
 
 const debugFailure = DEBUG('audit:collab:fail')
 const debugSuccess = DEBUG('audit:collab:success')
-const debugSuperSuccess = DEBUG('audit:admin:success')
-const debugSuperFailure = DEBUG('audit:admin:fail')
 
 export const checkTokenHeader =
   (authService: AuthService, audience?: string) => async (req: RequestWithUser, res: Response, next: NextFunction) => {
@@ -141,6 +133,10 @@ const checkPermissions =
       return new ForbiddenError(`User "${email}" doesn't have access to workspace "${req.workspace}"`)
     }
 
+    if (req.params.botId && !(await workspaceService.isBotInWorkspace(req.workspace, req.params.botId))) {
+      return new NotFoundError(`Bot "${req.params.botId}" doesn't exist in workspace "${req.workspace}"`)
+    }
+
     const role = await workspaceService.getRoleForUser(email, strategy, req.workspace)
 
     if (!role || !checkRule(role.rules, operation, resource)) {
@@ -157,7 +153,7 @@ export const checkBotVisibility =
     // '___' is a non-valid botId, but here acts as for "all bots"
     // This is used in modules when they setup routes that work on a global level (they are not tied to a specific bot)
     // Check the 'sso-login' module for an example
-    if (req.params.botId === '___' || req.originalUrl.endsWith('env.js')) {
+    if (req.params.botId === '___' || req.originalUrl.endsWith('env')) {
       return next()
     }
 

--- a/packages/studio-be/src/core/users/workspace-service.ts
+++ b/packages/studio-be/src/core/users/workspace-service.ts
@@ -104,4 +104,13 @@ export class WorkspaceService {
     const user = await this.findUser(email, strategy, workspace)!
     return user && this.findRole(user.role!, workspace)
   }
+
+  async isBotInWorkspace(workspaceId: string, botId: string): Promise<boolean> {
+    try {
+      const workspace = await this.findWorkspace(workspaceId)
+      return workspace.bots.includes(botId)
+    } catch (err) {
+      return false
+    }
+  }
 }


### PR DESCRIPTION
This simple PR ensures that a user really has access to a bot targeted by a request. Before this change, a user could perform some actions on a chatbot from a foreign workspace.