### PR TITLE
fix(auth): fix authenticating with cookie storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/studio",
-  "version": "0.0.56",
+  "version": "0.0.55",
   "description": "Create your virtual assistants",
   "repository": "https://github.com/botpress/studio.git",
   "author": "Botpress, Inc.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@botpress/studio",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "description": "Create your virtual assistants",
   "repository": "https://github.com/botpress/studio.git",
   "author": "Botpress, Inc.",

--- a/packages/studio-be/api.rest
+++ b/packages/studio-be/api.rest
@@ -2,7 +2,7 @@
 
 
 ### Send a request using Converse
-GET  http://localhost:3002/api/v1/studio/welcome-bot/env.js
+GET  http://localhost:3002/api/v1/studio/welcome-bot/public-env.js
 Content-Type: application/json
 
 {

--- a/packages/studio-be/src/core/app/server.ts
+++ b/packages/studio-be/src/core/app/server.ts
@@ -40,7 +40,7 @@ import { debugRequestMw, resolveStudioAsset } from './server-utils'
 const BASE_API_PATH = '/api/v1'
 
 const getSocketTransports = (config: BotpressConfig): string[] => {
-  const transports = _.filter(config.httpServer.socketTransports, t => ['websocket', 'polling'].includes(t))
+  const transports = _.filter(config.httpServer.socketTransports, (t) => ['websocket', 'polling'].includes(t))
   return transports && transports.length ? transports : ['websocket', 'polling']
 }
 
@@ -147,7 +147,6 @@ export class HTTPServer {
 
     return {
       SEND_USAGE_STATS: config!.sendUsageStats,
-      USE_JWT_COOKIES: process.USE_JWT_COOKIES,
       EXPERIMENTAL: config.experimental,
       SOCKET_TRANSPORTS: getSocketTransports(config),
       SHOW_POWERED_BY: !!config.showPoweredBy,
@@ -285,7 +284,7 @@ export class HTTPServer {
     process.LOCAL_URL = `http://localhost:${process.PORT}${process.ROOT_PATH}`
     process.EXTERNAL_URL = process.env.EXTERNAL_URL || config.externalUrl || `http://${process.HOST}:${process.PORT}`
 
-    await Promise.fromCallback(callback => {
+    await Promise.fromCallback((callback) => {
       this.httpServer.listen(process.PORT, undefined, config.backlog, () => callback(undefined))
     })
 

--- a/packages/studio-be/src/studio/studio-router.ts
+++ b/packages/studio-be/src/studio/studio-router.ts
@@ -232,7 +232,7 @@ export class StudioRouter extends CustomRouter {
               window.APP_NAME = "${removeHtmlChars(branding.title)}";
               window.APP_FAVICON = "${removeHtmlChars(branding.favicon)}";
               window.APP_CUSTOM_CSS = "${removeHtmlChars(branding.customCss)}";
-              window.USE_JWT_COOKIES = "${process.USE_JWT_COOKIES}";
+              window.USE_JWT_COOKIES = ${process.USE_JWT_COOKIES};
             })(typeof window != 'undefined' ? window : {})
           `
 

--- a/packages/studio-be/src/studio/studio-router.ts
+++ b/packages/studio-be/src/studio/studio-router.ts
@@ -133,7 +133,7 @@ export class StudioRouter extends CustomRouter {
 
     app.use('/api/internal', this.internalRouter.router)
 
-    app.use(rewrite('/studio/:botId/*branding.js', '/api/v1/studio/:botId/branding.js'))
+    app.use(rewrite('/studio/:botId/*public-env.js', '/api/v1/studio/:botId/public-env.js'))
     app.use(rewrite('/studio/:botId/*env', '/api/v1/studio/:botId/env'))
 
     // TODO: Temporary in case we forgot to change it somewhere
@@ -216,7 +216,7 @@ export class StudioRouter extends CustomRouter {
      * Do not return sensitive information there. These must be accessible by unauthenticated users
      */
     this.router.get(
-      '/branding.js',
+      '/public-env.js',
       this.asyncMiddleware(async (req, res) => {
         const { botId } = req.params
 
@@ -232,6 +232,7 @@ export class StudioRouter extends CustomRouter {
               window.APP_NAME = "${removeHtmlChars(branding.title)}";
               window.APP_FAVICON = "${removeHtmlChars(branding.favicon)}";
               window.APP_CUSTOM_CSS = "${removeHtmlChars(branding.customCss)}";
+              window.USE_JWT_COOKIES = "${process.USE_JWT_COOKIES}";
             })(typeof window != 'undefined' ? window : {})
           `
 

--- a/packages/studio-ui/src/web/index.html
+++ b/packages/studio-ui/src/web/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
     <meta name="description" content="" />
     <meta name="keywords" content="" />
-    <script src="branding.js"></script>
+    <script src="public-env.js"></script>
     <script>
       window.ROOT_PATH = ''
     </script>


### PR DESCRIPTION
This PR fixes an issue where when the JWT token was stored in the cookie storage, the call to `/env` would fail with a 401. The request was denied because the `window` variable '`USE_JWT_COOKIES`' was not set at this point.

To fix the problem, I renamed the `/branding.js` call to `/public-env.js` so that we can send any **public** environment variable to the front-end without authentication and passed the value of `process.USE_JWT_COOKIES` in it.