### PR TITLE
fix(security): fix access to public envs when bot is unmounted

### DIFF
--- a/packages/studio-be/src/core/security/router-security.ts
+++ b/packages/studio-be/src/core/security/router-security.ts
@@ -156,7 +156,7 @@ export const checkBotVisibility =
     // '___' is a non-valid botId, but here acts as for "all bots"
     // This is used in modules when they setup routes that work on a global level (they are not tied to a specific bot)
     // Check the 'sso-login' module for an example
-    if (req.params.botId === '___' || req.originalUrl.endsWith('env')) {
+    if (req.params.botId === '___' || req.originalUrl.endsWith('env') || req.originalUrl.endsWith('env.js')) {
       return next()
     }
 


### PR DESCRIPTION
This PR fixes an issue where unmounting a bot would prevent the user from accessing the bot settings page.

The issue came from the `checkBotVisibility` middleware that checks whether or not the bot is accessible (mounted). It contains an exception for the `/env` route and placeholder bots (`___`). Meaning that we were missing the exception for the `public-env` route. 