### PR TITLE
fix(debugger): fix display of log timestamp

### DIFF
--- a/packages/studio-ui/src/web/components/Layout/BottomPanel/Logs/index.tsx
+++ b/packages/studio-ui/src/web/components/Layout/BottomPanel/Logs/index.tsx
@@ -88,7 +88,7 @@ class BottomPanel extends React.Component<Props, State> {
         return
       }
 
-      this.logs.push(this.makeLogEntry({ ...log, timestamp: Date.now().toString() }))
+      this.logs.push(this.makeLogEntry({ ...log, timestamp: new Date().toISOString() }))
 
       if (this.logs.length > MAX_LOGS_LIMIT) {
         this.logs.shift()


### PR DESCRIPTION
This PR fixes the display of the date in the studio's debugger.

**before**

![Screen Shot 2022-07-27 at 10 33 09 AM](https://user-images.githubusercontent.com/9640576/181286435-da1cb0b3-9bf5-4666-9abd-fa6a84be7ef6.png)

**after**

![Screenshot from 2022-07-27 11-24-04](https://user-images.githubusercontent.com/9640576/181286470-1a40475a-3429-443a-97a3-c4c69976399f.png)
