### PR TITLE
feat(studio): preview content elements from skills

### DIFF
--- a/packages/studio-be/src/core/dialog/skill-service.ts
+++ b/packages/studio-be/src/core/dialog/skill-service.ts
@@ -21,7 +21,11 @@ export class SkillService {
     }
 
     // TODO change when studio is updated, since actual doesn't support catchall
-    return { flow: completeFlow, transitions: partialFlow.transitions }
+    return {
+      flow: completeFlow,
+      transitions: partialFlow.transitions,
+      ...(partialFlow.previewElements && { previewElements: partialFlow.previewElements })
+    }
   }
 
   private parseActionQuery(nodes): string[] | undefined {

--- a/packages/studio-be/src/sdk/botpress.d.ts
+++ b/packages/studio-be/src/sdk/botpress.d.ts
@@ -1184,6 +1184,8 @@ declare module 'botpress/sdk' {
     flow: SkillFlow
     /** An array of possible transitions for the parent node */
     transitions: NodeTransition[]
+    /** Elements to be previewed in the skill node */
+    previewElements?: string[]
   }
 
   /**

--- a/packages/studio-be/src/sdk/botpress.d.ts
+++ b/packages/studio-be/src/sdk/botpress.d.ts
@@ -1185,7 +1185,7 @@ declare module 'botpress/sdk' {
     /** An array of possible transitions for the parent node */
     transitions: NodeTransition[]
     /** Elements to be previewed in the skill node */
-    previewElements?: string[]
+    previewElements?: string[] | null
   }
 
   /**

--- a/packages/studio-ui/src/web/reducers/flows.ts
+++ b/packages/studio-ui/src/web/reducers/flows.ts
@@ -522,7 +522,8 @@ reducer = reduceReducers(
           flow: flowName,
           next: payload.transitions || [],
           onEnter: null,
-          onReceive: null
+          onReceive: null,
+          previewElements: payload.previewElements
         }
 
         const newFlowHash = computeHashForFlow(newFlow)
@@ -561,6 +562,7 @@ reducer = reduceReducers(
 
           return {
             ...node,
+            previewElements: payload.previewElements,
             next: payload.transitions.map((transition) => {
               const prevTransition =
                 node.next.find(({ condition }) => condition === transition.condition) ||

--- a/packages/studio-ui/src/web/views/FlowBuilder/diagram/manager.ts
+++ b/packages/studio-ui/src/web/views/FlowBuilder/diagram/manager.ts
@@ -22,6 +22,7 @@ const passThroughNodeProps: string[] = [
   'onReceive',
   'next',
   'skill',
+  'previewElements',
   'conditions',
   'type',
   'content',
@@ -583,7 +584,7 @@ export class DiagramManager {
     const model = this.activeModel.serializeDiagram()
     const nodes = model.nodes.map((node: any) => {
       return {
-        ..._.pick(node, 'id', 'name', 'onEnter', 'onReceive'),
+        ..._.pick(node, 'id', 'name', 'onEnter', 'onReceive', 'previewElements'),
         next: node.next.map((next, index) => {
           const port = _.find(node.ports, { name: `out${index}` })
 

--- a/packages/studio-ui/src/web/views/FlowBuilder/diagram/nodes/Block/index.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/diagram/nodes/Block/index.tsx
@@ -235,6 +235,7 @@ export class BlockModel extends BaseNodeModel {
   public content?: FormData
   public flow: string
   public skill?: string
+  public previewElements?: string[]
 
   constructor({
     id,
@@ -244,6 +245,7 @@ export class BlockModel extends BaseNodeModel {
     type,
     flow,
     skill,
+    previewElements,
     content,
     onEnter = [],
     next = [],
@@ -264,6 +266,7 @@ export class BlockModel extends BaseNodeModel {
       next,
       flow,
       skill,
+      previewElements,
       isStartNode,
       isHighlighted,
       conditions,
@@ -286,6 +289,7 @@ export class BlockModel extends BaseNodeModel {
     this.content = data.content
     this.flow = data.flow
     this.skill = data.skill
+    this.previewElements = data.previewElements
     this.isReadOnly = data.isReadOnly
   }
 }

--- a/packages/studio-ui/src/web/views/FlowBuilder/diagram/nodes/Block/index.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/diagram/nodes/Block/index.tsx
@@ -235,7 +235,7 @@ export class BlockModel extends BaseNodeModel {
   public content?: FormData
   public flow: string
   public skill?: string
-  public previewElements?: string[]
+  public previewElements?: string[] | null
 
   constructor({
     id,

--- a/packages/studio-ui/src/web/views/FlowBuilder/diagram/nodes/SkillCallContents/index.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/diagram/nodes/SkillCallContents/index.tsx
@@ -21,6 +21,15 @@ type Props = Pick<BlockProps, 'node'>
 const SkillCallContents: FC<Props> = ({ node }) => {
   return (
     <div className={cx(style.contentsWrapper, style['skill-call'])}>
+      {node.previewElements?.map((item, i) => {
+        return (
+          <ActionItem
+            key={`${i}.${item}`}
+            className={cx(style.contentWrapper, style.content, localStyle.item)}
+            text={`say #!${item}`}
+          />
+        )
+      })}
       {node.onReceive?.map((item, i) => {
         return (
           <ActionItem

--- a/packages/studio-ui/src/web/views/FlowBuilder/skills/index.jsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/skills/index.jsx
@@ -65,7 +65,7 @@ class SkillsBuilder extends React.Component {
       canSubmit: false
     })
 
-    return this.generateFlow().then(generated => {
+    return this.generateFlow().then((generated) => {
       if (this.props.action === 'edit') {
         this.props.updateSkill({
           skillId: this.props.skillId,
@@ -73,7 +73,8 @@ class SkillsBuilder extends React.Component {
           generatedFlow: generated.flow,
           transitions: generated.transitions,
           editFlowName: this.props.editFlowName,
-          editNodeId: this.props.editNodeId
+          editNodeId: this.props.editNodeId,
+          previewElements: generated.previewElements
         })
       } else {
         this.props.insertNewSkill({
@@ -81,7 +82,8 @@ class SkillsBuilder extends React.Component {
           data: this.data,
           generatedFlow: generated.flow,
           transitions: generated.transitions,
-          location: this.props.location
+          location: this.props.location,
+          previewElements: generated.previewElements
         })
       }
     })


### PR DESCRIPTION
This feature allows the flow generator to return a list of content elements to be previewed in the flow editor.

Example: 

![image](https://user-images.githubusercontent.com/13484138/184997507-39772f8c-2075-47d0-aa36-528bdcbc6a8f.png)

The content element ids are saved in the node definition (same logic as transitions)

![image](https://user-images.githubusercontent.com/13484138/184997742-b96e6eb2-dd0d-4bd2-8b21-998dc1be378b.png)

It can be specified in the flow generator function in the return object.

![image](https://user-images.githubusercontent.com/13484138/184998045-59cd4b12-21cc-470d-b963-c46764d6ea69.png)
