### PR TITLE
fix(studio): fix img renderer for node preview

### DIFF
--- a/packages/studio-ui/src/web/views/FlowBuilder/common/ActionItem.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/common/ActionItem.tsx
@@ -65,7 +65,7 @@ class ActionItem extends Component<Props> {
       [style.missingTranslation]: preview?.startsWith('(missing translation) ')
     })
 
-    if (preview && item?.schema?.title === 'Image') {
+    if (preview && item?.schema?.title === 'image') {
       const markdownRender = (
         <Markdown
           source={preview}

--- a/packages/studio-ui/src/web/views/FlowBuilder/common/style.scss
+++ b/packages/studio-ui/src/web/views/FlowBuilder/common/style.scss
@@ -94,7 +94,7 @@
 }
 
 .imagePreview {
-  height: 60px;
+  height: 40px;
 }
 
 .rtl {

--- a/packages/studio-ui/src/web/views/FlowBuilder/common/style.scss
+++ b/packages/studio-ui/src/web/views/FlowBuilder/common/style.scss
@@ -94,7 +94,7 @@
 }
 
 .imagePreview {
-  width: 140px;
+  height: 60px;
 }
 
 .rtl {


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/13484138/185483403-ef805969-cba9-4f09-ac47-5006f804aa60.png)

After: 

![image](https://user-images.githubusercontent.com/13484138/185484045-ec4bba56-ce43-4f48-b037-ed4c19dc8912.png)
