### PR TITLE
chore(dx): clean out folders before building

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Botpress, Inc.",
   "license": "AGPL-3.0",
   "scripts": {
-    "build": "yarn workspaces foreach -ptiv run build",
+    "build": "yarn clean && yarn workspaces foreach -ptiv run build",
     "watch": "yarn workspaces foreach -piv run watch",
     "clean": "yarn workspaces foreach -pi run clean",
     "start": "ts-node -T --dir scripts start_studio",


### PR DESCRIPTION
This PR fixes an issue where in some cases, not deleting the out folder in the backend would result in deleted files being resolved.