### PR TITLE
feat(studio): allow third party content types to preview images

### DIFF
--- a/packages/studio-ui/src/web/util.ts
+++ b/packages/studio-ui/src/web/util.ts
@@ -63,3 +63,20 @@ export const sanitizeName = (text: string) =>
 export const stripDots = (str: string) => str.replace(/\./g, '--dot--')
 
 export const restoreDots = (str: string) => str.replace(/--dot--/g, '.')
+
+export const recursiveSearch = (obj, searchKey, results = []) => {
+  const r = results
+  if (typeof obj !== 'object') {
+    return r
+  }
+
+  Object.keys(obj).forEach((key) => {
+    const value = obj[key]
+    if (key === searchKey && typeof value !== 'object') {
+      r.push(value)
+    } else if (typeof value === 'object') {
+      recursiveSearch(value, searchKey, r)
+    }
+  })
+  return r
+}

--- a/packages/studio-ui/src/web/views/FlowBuilder/common/ActionItem.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/common/ActionItem.tsx
@@ -9,7 +9,7 @@ import { fetchContentItem, refreshFlowsLinks } from '~/actions'
 
 import { isMissingCurlyBraceClosure } from '~/components/Util/form.util'
 import { isRTLLocale } from '~/translations'
-import { restoreDots, stripDots } from '~/util'
+import { restoreDots, stripDots, recursiveSearch } from '~/util'
 import withLanguage from '../../../components/Util/withLanguage'
 import { ActionPopover } from './ActionPopover'
 
@@ -65,7 +65,9 @@ class ActionItem extends Component<Props> {
       [style.missingTranslation]: preview?.startsWith('(missing translation) ')
     })
 
-    if (preview && item?.schema?.title === 'Image') {
+    const hasImageSubtype = recursiveSearch(item?.schema?.json, '$subtype')?.indexOf('image') !== -1
+
+    if (preview && hasImageSubtype) {
       const markdownRender = (
         <Markdown
           source={preview}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13484138/186029464-d1c87339-50f5-4aef-bb9f-90918593a5c7.png)

Allow other content types which are not the "image" content type to render images in the preview