### PR TITLE
fix(studio): fix NLU utterances placeholder on Chromium

### DIFF
--- a/packages/studio-ui/package.json
+++ b/packages/studio-ui/package.json
@@ -80,7 +80,6 @@
     "reselect": "^4.0.0",
     "slate": "0.47.4",
     "slate-react": "0.22.4",
-    "slate-react-placeholder": "0.2.4",
     "snarkdown": "^1.2.2",
     "socket.io-client": "^4.4.1",
     "storm-react-diagrams": "^5.2.1",

--- a/packages/studio-ui/src/web/views/Nlu/intents/UtterancesEditor.tsx
+++ b/packages/studio-ui/src/web/views/Nlu/intents/UtterancesEditor.tsx
@@ -22,23 +22,10 @@ import {
   ValueJSON
 } from 'slate'
 import { Editor, EditorProps, RenderBlockProps, RenderMarkProps } from 'slate-react'
-import PlaceholderPlugin from 'slate-react-placeholder'
 
 import { TagSlotPopover } from './slots/SlotPopover'
 import style from './style.scss'
 import { makeSlotMark, utterancesToValue, valueToUtterances } from './utterances-state-utils'
-
-const plugins = [
-  PlaceholderPlugin({
-    placeholder: lang.tr('nlu.intents.utterancePlaceholder'),
-    when: (_, node) => node.text.trim() === '',
-    style: {
-      display: 'inline-block',
-      transform: 'translateX(var(--hanging-indent))',
-      verticalAlign: 'inherit'
-    }
-  })
-]
 
 interface Props {
   intentName: string
@@ -148,7 +135,6 @@ export class UtterancesEditor extends React.Component<Props, State> {
       // @ts-ignore
       <Editor
         value={this.state.value}
-        plugins={plugins}
         renderMark={this.renderMark}
         renderEditor={this.renderEditor}
         renderBlock={this.renderBlock}
@@ -378,6 +364,7 @@ export class UtterancesEditor extends React.Component<Props, State> {
               {utteranceIdx + 1}
             </span>
             {children}
+            {isEmpty && <span className={style.placeholder}>{lang.tr('nlu.intents.utterancePlaceholder')}</span>}
           </p>
         )
         return utterance

--- a/packages/studio-ui/src/web/views/Nlu/intents/style.scss
+++ b/packages/studio-ui/src/web/views/Nlu/intents/style.scss
@@ -31,8 +31,21 @@
   }
 }
 
+.utterances > div > p {
+  position: relative;
+}
+
 .utterances p {
   margin-bottom: 0;
+}
+
+.placeholder {
+  color: silver;
+  position: absolute;
+  left: 50px;
+  top: 0px;
+  z-index: 0;
+  user-select: none;
 }
 
 .entities-list {

--- a/packages/studio-ui/src/web/views/Nlu/intents/style.scss.d.ts
+++ b/packages/studio-ui/src/web/views/Nlu/intents/style.scss.d.ts
@@ -28,6 +28,7 @@ interface CssExports {
   'label-colors-8': string;
   'link': string;
   'liteIntentEditor': string;
+  'placeholder': string;
   'selectionText': string;
   'shortcutLabel': string;
   'slotMark': string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1513,7 +1513,6 @@ __metadata:
     script-loader: ^0.7.0
     slate: 0.47.4
     slate-react: 0.22.4
-    slate-react-placeholder: 0.2.4
     snarkdown: ^1.2.2
     socket.io-client: ^4.4.1
     storm-react-diagrams: ^5.2.1
@@ -19108,17 +19107,6 @@ __metadata:
     immutable: ">=3.8.1"
     slate: ">=0.32.0 <0.50.0"
   checksum: 6ef3632255383ef3a8a13e0f52c191a7b1d23064bf5f14f8f316555f2d63ac32dc9e8d429fa742ce7219caa32e69a9163d24f36d5c6789d1c9b14a4158eea339
-  languageName: node
-  linkType: hard
-
-"slate-react-placeholder@npm:0.2.4":
-  version: 0.2.4
-  resolution: "slate-react-placeholder@npm:0.2.4"
-  peerDependencies:
-    react: ">=16.0.0"
-    slate: ">=0.47.0"
-    slate-react: ">=0.22.0"
-  checksum: bda4e7a48c5bc1a1a87a53d903670cf7c4b95afc5d6cfe569eba4ffec95645445c459d13a6899e7ea304d30a7f35990e573a4f7f5db8a19722bc03f1762dc696
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This fixes an issue with the utterances editor on the latest version of Chromium and related browsers

Before:


https://user-images.githubusercontent.com/13484138/191140116-6ad37f11-291f-4341-980c-213dbe70eb0d.mp4

After:

https://user-images.githubusercontent.com/13484138/191140132-c45b0043-000d-426b-86e8-c9c18815e880.mp4

I Fixed it by reimplementing the faulty plugin, which caused the bug
