### PR TITLE
fix(studio): click on placeholder will focus on input field

### DIFF
--- a/packages/studio-ui/src/web/views/Nlu/intents/style.scss
+++ b/packages/studio-ui/src/web/views/Nlu/intents/style.scss
@@ -46,6 +46,7 @@
   top: 0px;
   z-index: 0;
   user-select: none;
+  pointer-events: none;
 }
 
 .entities-list {


### PR DESCRIPTION
Pretty simple fix, clicking on the placeholder will also focus on the input field

![image](https://user-images.githubusercontent.com/13484138/197267193-64906cda-da0a-4662-877a-779a82b21802.png)


Related: https://github.com/botpress/botpress/discussions/12162#discussioncomment-3934730