### PR TITLE
fix(ui): prevent long content type to overflow

### DIFF
--- a/packages/studio-ui/src/web/views/FlowBuilder/common/style.scss
+++ b/packages/studio-ui/src/web/views/FlowBuilder/common/style.scss
@@ -65,6 +65,7 @@
   display: flex;
   align-items: center;
   color: var(--shark);
+  max-width: 300px;
 
   .icon {
     padding: var(--spacing-x-small);
@@ -82,6 +83,7 @@
     line-height: 1.25;
     overflow: hidden;
     white-space: nowrap;
+    text-overflow: ellipsis;
 
     span {
       padding: 2px 4px;

--- a/packages/studio-ui/src/web/views/FlowBuilder/common/style.scss
+++ b/packages/studio-ui/src/web/views/FlowBuilder/common/style.scss
@@ -65,6 +65,7 @@
   display: flex;
   align-items: center;
   color: var(--shark);
+  overflow: hidden;
   max-width: 300px;
 
   .icon {


### PR DESCRIPTION
While fixing another issue, I had this very annoying overflow behaviour where very long content elements would overflow out of the drag n drop section and causing a hover flicker.

**Before**:
<img width="553" alt="Screen Shot 2022-10-24 at 12 05 47 PM" src="https://user-images.githubusercontent.com/955524/197573661-d49d9125-89cf-4dcc-8245-6af368cdb9cf.png">


<img width="461" alt="Screen Shot 2022-10-24 at 12 31 43 PM" src="https://user-images.githubusercontent.com/955524/197578022-824c66ed-09e1-4188-a6de-fdbb1e25b5ce.png">

**After**:
<img width="359" alt="Screen Shot 2022-10-24 at 12 03 54 PM" src="https://user-images.githubusercontent.com/955524/197573444-68a882b1-de20-424d-9842-ebc4e67fc62d.png">
<img width="387" alt="Screen Shot 2022-10-24 at 12 30 29 PM" src="https://user-images.githubusercontent.com/955524/197578098-4a476e59-5423-47db-99f6-2d8a0eeea001.png">
