### PR TITLE
fix: properly set content type form step

### DIFF
--- a/packages/studio-ui/src/web/actions/index.ts
+++ b/packages/studio-ui/src/web/actions/index.ts
@@ -293,7 +293,7 @@ export const receiveContentItem = createAction('CONTENT/ITEMS/RECEIVE_ONE')
 export const fetchContentItem =
   (id: string, { force = false, batched = false } = {}) =>
   (dispatch, getState): Promise<sdk.ContentElement> => {
-    if (!force && getState().content.itemsById[id]) {
+    if (!id || (!force && getState().content.itemsById[id])) {
       return Promise.resolve(getState().content.itemsById[id])
     }
 

--- a/packages/studio-ui/src/web/components/Content/Select/index.tsx
+++ b/packages/studio-ui/src/web/components/Content/Select/index.tsx
@@ -59,7 +59,7 @@ class SelectContent extends Component<Props, State> {
       show: true,
       contentType,
       activeItemIndex: 0,
-      step: FormSteps.INITIAL,
+      step: contentType ? FormSteps.MAIN : FormSteps.INITIAL,
       newItemCategory: null,
       searchTerm: '',
       newItemData: null


### PR DESCRIPTION
This PR fixes 2 issues that are mentioned [here](https://github.com/botpress/botpress/discussions/12141#discussioncomment-3939768)

1- It prevent to fetch invalid or undefined content element (the issue causing the 504)
2- Properly initializes the content type selector form when the category is already defined. (Issue is coming from the fact that I brought this piece of code from cloud studio which has a different behavior)

**before: forever spinning wheel**
<img width="1026" alt="Screen Shot 2022-10-24 at 12 13 47 PM" src="https://user-images.githubusercontent.com/955524/197575664-e0d11e4b-6475-4043-a1a8-55ed61836353.png">

**before: create or select content item=**
<img width="948" alt="Screen Shot 2022-10-24 at 12 12 06 PM" src="https://user-images.githubusercontent.com/955524/197575656-5dcb2e5b-c386-4d8c-814a-40021bee7b3a.png">
