### PR TITLE
feat: double click on draggable item to edit

### DIFF
--- a/packages/studio-ui/src/web/views/FlowBuilder/common/DraggableNodeItem.tsx
+++ b/packages/studio-ui/src/web/views/FlowBuilder/common/DraggableNodeItem.tsx
@@ -57,6 +57,7 @@ const DraggableNodeItem = <T,>(props: PropsWithChildren<Props<T>>) => {
           {...provided.dragHandleProps}
           onMouseEnter={() => setDisplayActionElements(true)}
           onMouseLeave={() => setDisplayActionElements(false)}
+          onDoubleClick={() => onEdit(item, index)}
         >
           <div className={style.handle}>{displayActionElements && <Icon icon="drag-handle-vertical" />}</div>
           <div className={style.content}>{itemRenderer(item, index)}</div>


### PR DESCRIPTION
Pretty simple and straight forward. This simple change allows a user to edit a node item by double clicking a draggable node item. One liner time saver for all bot builders