### PR TITLE
feat(studio): add help button

### DIFF
--- a/packages/studio-ui/src/web/components/Layout/Toolbar/index.tsx
+++ b/packages/studio-ui/src/web/components/Layout/Toolbar/index.tsx
@@ -25,7 +25,6 @@ const FORUM_LINK = 'https://github.com/botpress/botpress/discussions'
 const DOCS_LINK = 'https://v12.botpress.com/'
 
 const Toolbar: FC<Props> = (props) => {
-  const [isHelpPopoverOpen, setHelpPopoverOpen] = useState(false)
   const { toggleDocs, toggleGuidedTour, hasDoc, onToggleEmulator, isEmulatorOpen, toggleBottomPanel } = props
 
   return (
@@ -58,29 +57,32 @@ const Toolbar: FC<Props> = (props) => {
                   content={
                     <Menu>
                       <MenuItem icon="learning" text={lang.tr('toolbar.tutorial')} onClick={toggleGuidedTour} />
-                      <MenuItem icon="people" text={lang.tr('toolbar.forum')} onClick={() => window.open(FORUM_LINK)} />
-                      <MenuItem icon="book" text={lang.tr('toolbar.docs')} onClick={() => window.open(DOCS_LINK)} />
+                      <MenuItem
+                        icon="people"
+                        text={lang.tr('toolbar.forum')}
+                        onClick={() => window.open(FORUM_LINK, '_blank')}
+                      />
+                      <MenuItem
+                        icon="book"
+                        text={lang.tr('toolbar.docs')}
+                        onClick={() => window.open(DOCS_LINK, '_blank')}
+                      />
                     </Menu>
                   }
+                  target={
+                    <button id="statusbar_tutorial" className={style.item}>
+                      <Icon color="#1a1e22" icon="help" iconSize={16} />
+                      <span className={style.label}>{lang.tr('toolbar.help')}</span>
+                    </button>
+                  }
                   minimal
-                  isOpen={isHelpPopoverOpen}
                   position={Position.TOP_RIGHT}
                   canEscapeKeyClose
-                  onClose={() => setHelpPopoverOpen(false)}
                   fill
                   modifiers={{
                     preventOverflow: { enabled: true, boundariesElement: 'window' }
                   }}
-                >
-                  <button
-                    id="statusbar_tutorial"
-                    className={style.item}
-                    onClick={() => setHelpPopoverOpen(!isHelpPopoverOpen)}
-                  >
-                    <Icon color="#1a1e22" icon="help" iconSize={16} />
-                    <span className={style.label}>{lang.tr('toolbar.help')}</span>
-                  </button>
-                </Popover>
+                />
               </Tooltip>
             </Fragment>
           )}

--- a/packages/studio-ui/src/web/components/Layout/Toolbar/index.tsx
+++ b/packages/studio-ui/src/web/components/Layout/Toolbar/index.tsx
@@ -1,7 +1,7 @@
-import { Icon, Tooltip } from '@blueprintjs/core'
+import { Icon, Tooltip, Popover, Position, Menu, MenuItem } from '@blueprintjs/core'
 import { lang, ShortcutLabel } from 'botpress/shared'
 import classNames from 'classnames'
-import React, { FC, Fragment } from 'react'
+import React, { FC, Fragment, useState } from 'react'
 import { connect } from 'react-redux'
 import { AccessControl } from '~/components/Shared/Utils'
 
@@ -21,8 +21,10 @@ interface OwnProps {
 type StateProps = ReturnType<typeof mapStateToProps>
 
 type Props = StateProps & OwnProps
+const FORUM_LINK = 'https://github.com/botpress/botpress/discussions'
 
 const Toolbar: FC<Props> = (props) => {
+  const [isHelpPopoverOpen, setHelpPopoverOpen] = useState(false)
   const { toggleDocs, toggleGuidedTour, hasDoc, onToggleEmulator, isEmulatorOpen, toggleBottomPanel } = props
 
   return (
@@ -51,10 +53,32 @@ const Toolbar: FC<Props> = (props) => {
           ) : (
             <Fragment>
               <Tooltip content={<div>{lang.tr('toolbar.help')}</div>}>
-                <button id="statusbar_tutorial" className={style.item} onClick={toggleGuidedTour}>
-                  <Icon color="#1a1e22" icon="help" iconSize={16} />
-                  <span className={style.label}>{lang.tr('toolbar.tutorial')}</span>
-                </button>
+                <Popover
+                  content={
+                    <Menu>
+                      <MenuItem icon="learning" text={lang.tr('toolbar.tutorial')} onClick={toggleGuidedTour} />
+                      <MenuItem icon="chat" text={lang.tr('toolbar.forum')} onClick={() => window.open(FORUM_LINK)} />
+                    </Menu>
+                  }
+                  minimal
+                  isOpen={isHelpPopoverOpen}
+                  position={Position.TOP_RIGHT}
+                  canEscapeKeyClose
+                  onClose={() => setHelpPopoverOpen(false)}
+                  fill
+                  modifiers={{
+                    preventOverflow: { enabled: true, boundariesElement: 'window' }
+                  }}
+                >
+                  <button
+                    id="statusbar_tutorial"
+                    className={style.item}
+                    onClick={() => setHelpPopoverOpen(!isHelpPopoverOpen)}
+                  >
+                    <Icon color="#1a1e22" icon="help" iconSize={16} />
+                    <span className={style.label}>{lang.tr('toolbar.help')}</span>
+                  </button>
+                </Popover>
               </Tooltip>
             </Fragment>
           )}

--- a/packages/studio-ui/src/web/components/Layout/Toolbar/index.tsx
+++ b/packages/studio-ui/src/web/components/Layout/Toolbar/index.tsx
@@ -22,6 +22,7 @@ type StateProps = ReturnType<typeof mapStateToProps>
 
 type Props = StateProps & OwnProps
 const FORUM_LINK = 'https://github.com/botpress/botpress/discussions'
+const DOCS_LINK = 'https://v12.botpress.com/'
 
 const Toolbar: FC<Props> = (props) => {
   const [isHelpPopoverOpen, setHelpPopoverOpen] = useState(false)
@@ -57,7 +58,8 @@ const Toolbar: FC<Props> = (props) => {
                   content={
                     <Menu>
                       <MenuItem icon="learning" text={lang.tr('toolbar.tutorial')} onClick={toggleGuidedTour} />
-                      <MenuItem icon="chat" text={lang.tr('toolbar.forum')} onClick={() => window.open(FORUM_LINK)} />
+                      <MenuItem icon="people" text={lang.tr('toolbar.forum')} onClick={() => window.open(FORUM_LINK)} />
+                      <MenuItem icon="book" text={lang.tr('toolbar.docs')} onClick={() => window.open(DOCS_LINK)} />
                     </Menu>
                   }
                   minimal

--- a/packages/studio-ui/src/web/translations/en.json
+++ b/packages/studio-ui/src/web/translations/en.json
@@ -567,6 +567,7 @@
     "toggleEmulator": "Toggle Emulator",
     "toggleSidePanel": "Toggle Side Panel",
     "tutorial": "Tutorial",
+    "docs": "Documentation",
     "forum": "Forum"
   },
   "bottomPanel": {

--- a/packages/studio-ui/src/web/translations/en.json
+++ b/packages/studio-ui/src/web/translations/en.json
@@ -566,7 +566,8 @@
     "toggleBottomPanel": "Toggle Bottom Panel",
     "toggleEmulator": "Toggle Emulator",
     "toggleSidePanel": "Toggle Side Panel",
-    "tutorial": "Tutorial"
+    "tutorial": "Tutorial",
+    "forum": "Forum"
   },
   "bottomPanel": {
     "inspector": {


### PR DESCRIPTION
As requested on https://linear.app/botpress/issue/GTM-309/add-buttons-to-v12-to-make-it-easier-for-users-to-get-help-in-the-v12 we added a Help button on the studio

![image](https://user-images.githubusercontent.com/13484138/225120306-5a086612-a69e-4ba0-a380-9de613959453.png)
